### PR TITLE
(PUP-1776) Load type requires properly on puppet master

### DIFF
--- a/lib/puppet/provider/acl/windows.rb
+++ b/lib/puppet/provider/acl/windows.rb
@@ -1,12 +1,14 @@
 require 'puppet/type'
+require 'pathname'
 
 Puppet::Type.type(:acl).provide :windows do
   #confine :feature => :microsoft_windows
   confine :operatingsystem => :windows
   defaultfor :operatingsystem => :windows
 
-  require 'puppet/type/acl/ace'
-  require 'puppet/provider/acl/windows/base'
+
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet/type/acl/ace'
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet/provider/acl/windows/base'
   include Puppet::Provider::Acl::Windows::Base
 
   has_features :ace_order_required

--- a/lib/puppet/provider/acl/windows/base.rb
+++ b/lib/puppet/provider/acl/windows/base.rb
@@ -1,8 +1,10 @@
+require 'pathname'
+
 class Puppet::Provider::Acl
   module Windows
     module Base
       if Puppet::Util::Platform.windows?
-        require 'puppet/type/acl/ace'
+        require Pathname.new(__FILE__).dirname + '../../../../' + 'puppet/type/acl/ace'
         require 'puppet/util/windows/security'
         require 'win32/security'
         require 'windows/security'

--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -1,8 +1,9 @@
 require 'puppet/type'
+require 'pathname'
 
 Puppet::Type.newtype(:acl) do
-  require 'puppet/type/acl/ace'
-  require 'puppet/type/acl/constants'
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/acl/ace'
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/acl/constants'
 
   @doc = <<-'EOT'
     Manages access control lists.  The `acl` type is typically


### PR DESCRIPTION
This ensures that when the type is loaded, we use a relative path to the
required files. Currently there are failure messages on the puppet master
when it loads the type because it doesn't add the individual module lib
directories to the LOAD__PATH.
