### PR TITLE
(PUP-1801) Manage owner if specified

### DIFF
--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -27,6 +27,10 @@ Puppet::Type.newtype(:acl) do
       self[:target] = self[:name]
     end
 
+    if self[:owner].nil? then
+      self[:owner] = Puppet::Type::Acl::Constants::OWNER_UNSPECIFIED
+    end
+
     if self[:group].nil? then
       self[:group] = Puppet::Type::Acl::Constants::GROUP_UNSPECIFIED
     end
@@ -110,8 +114,9 @@ Puppet::Type.newtype(:acl) do
       that is said to own the particular acl/security descriptor. This
       can be in the form of: 1. User - e.g. 'Bob' or 'TheNet\\Bob',
       2. Group e.g. 'Administrators' or 'BUILTIN\\Administrators', 3.
-      SID (Security ID) e.g. 'S-1-5-18'. Defaults to 'S-1-5-32-544'
-      (Administrators) on Windows."
+      SID (Security ID) e.g. 'S-1-5-18'. Defaults to not specified on
+      Windows. This allows owner to stay set to whatever it is currently
+      set to (owner can vary depending on the original CREATOR OWNER)."
 
     validate do |value|
       if value.nil? or value.empty?
@@ -119,10 +124,9 @@ Puppet::Type.newtype(:acl) do
       end
     end
 
-    #todo check platform and return specific default - this may not always be windows
-    defaultto 'S-1-5-32-544'
-
     def insync?(current)
+      return true if should == Puppet::Type::Acl::Constants::OWNER_UNSPECIFIED
+
       if provider.respond_to?(:owner_insync?)
         return provider.owner_insync?(current, should)
       end
@@ -228,11 +232,13 @@ Puppet::Type.newtype(:acl) do
       provider.class.send(:define_method,'get_account_name', &return_same_value)
     end
 
-    owner_name = provider.get_account_name(self[:owner])
+    unless self[:owner] == Puppet::Type::Acl::Constants::OWNER_UNSPECIFIED
+      owner_name = provider.get_account_name(self[:owner])
 
-    # add both qualified and unqualified items
-    required_users << "User[#{self[:owner]}]"
-    required_users << "User[#{owner_name}]"
+      # add both qualified and unqualified items
+      required_users << "User[#{self[:owner]}]"
+      required_users << "User[#{owner_name}]"
+    end
 
     permissions = self[:permissions]
     unless permissions.nil?

--- a/lib/puppet/type/acl/constants.rb
+++ b/lib/puppet/type/acl/constants.rb
@@ -1,5 +1,6 @@
 class Puppet::Type::Acl
   module Constants
-    GROUP_UNSPECIFIED = 'UserDefaultGroup'
+    GROUP_UNSPECIFIED = 'UserDefaultGroup+-=!'
+    OWNER_UNSPECIFIED = 'UserDefaultOwner+-=!'
   end
 end

--- a/spec/unit/provider/acl/windows_spec.rb
+++ b/spec/unit/provider/acl/windows_spec.rb
@@ -56,7 +56,8 @@ describe Puppet::Type.type(:acl).provider(:windows), :if => Puppet.features.micr
         test_should_not_set_autorequired_user('Administrators')
       end
 
-      it "should autorequire BUILTIN\\Administrators if owner is set to the default Administrators SID" do
+      it "should autorequire BUILTIN\\Administrators if owner is set to the Administrators SID" do
+        resource[:owner] = 'S-1-5-32-544'
         test_should_set_autorequired_user('BUILTIN\Administrators')
       end
 
@@ -72,8 +73,8 @@ describe Puppet::Type.type(:acl).provider(:windows), :if => Puppet.features.micr
   end
 
   context ":owner" do
-    it "should be set to Administrator SID by default" do
-      resource[:owner].must == 'S-1-5-32-544'
+    it "should be set to the default unspecified value by default" do
+      resource[:owner].must == Puppet::Type::Acl::Constants::OWNER_UNSPECIFIED
     end
 
     context ".insync?" do

--- a/spec/unit/type/acl_spec.rb
+++ b/spec/unit/type/acl_spec.rb
@@ -107,7 +107,12 @@ describe Puppet::Type.type(:acl) do
         reqs.must be_empty
       end
 
-      it "should autorequire owner" do
+      it "should not autorequire owner when set to unspecified" do
+        test_should_not_set_autorequired_user('Administrators')
+      end
+
+      it "should autorequire owner when set to Administrators" do
+        resource[:owner] = 'Administrators'
         test_should_set_autorequired_user(resource[:owner])
       end
 
@@ -233,8 +238,8 @@ describe Puppet::Type.type(:acl) do
   end
 
   context "property :owner" do
-    it "should default to S-1-5-32-544 (Administrators)" do
-      resource[:owner].must == 'S-1-5-32-544'
+    it "should default to use the default unspecified group" do
+      resource[:owner].must ==  Puppet::Type::Acl::Constants::OWNER_UNSPECIFIED
     end
 
     it "should accept bob" do


### PR DESCRIPTION
Owner should only be managed if specified. It can also vary depending on the
context of the user that creates the securable item and puppet should respect
that instead of trying to force a default.
