### PR TITLE
(PUP-1987) Deny ACL should inherit by default

### DIFF
--- a/lib/puppet/provider/acl/windows/base.rb
+++ b/lib/puppet/provider/acl/windows/base.rb
@@ -8,11 +8,12 @@ class Puppet::Provider::Acl
     module Base
       if Puppet::Util::Platform.windows?
         require Pathname.new(__FILE__).dirname + '../../../../' + 'puppet/type/acl/ace'
-        require Pathname.new(__FILE__).dirname + '../../../../' + 'puppet/util/monkey_patches'
         require 'puppet/util/windows/security'
         require 'win32/security'
         require 'windows/security'
         require 'windows/file'
+        # fixes come after everything else is loaded
+        require Pathname.new(__FILE__).dirname + '../../../../' + 'puppet/util/monkey_patches'
 
         REFRESH_SD        = true
         DO_NOT_REFRESH_SD = false

--- a/spec/integration/provider/acl/windows_spec.rb
+++ b/spec/integration/provider/acl/windows_spec.rb
@@ -361,7 +361,19 @@ describe Puppet::Type.type(:acl).provider(:windows), :if => Puppet.features.micr
         actual_perms.must == permissions
       end
 
-      #todo deny - this will be as the bug is fixed.
+      it "should handle deny" do
+        permissions = [
+            Puppet::Type::Acl::Ace.new({'identity' => 'Administrator','rights' => ['full'], 'type' => 'deny'}, provider),
+            Puppet::Type::Acl::Ace.new({'identity' => 'Administrators','rights' => ['full']}, provider)
+        ]
+        resource[:purge] = :true
+        provider.inherit_parent_permissions = :false
+
+        actual = set_perms(permissions)
+
+        actual.must == permissions
+      end
+
       it "should handle deny when affects => 'self_only'" do
         permissions = [
             Puppet::Type::Acl::Ace.new({'identity' => 'Administrator','rights' => ['full'], 'type' => 'deny', 'affects'=>'self_only'}, provider),


### PR DESCRIPTION
When setting deny with inheritance there is a bug in Puppet that doesn't use
the proper Windows library call to set access denied ACEs with the ability to set
inheritance and propagation flags. The fix for Puppet will go into 3.6.0 as
part of https://tickets.puppetlabs.com/browse/PUP-2100. This provides those
same fixes as a backport so ACL module can take advantage of the functionality
prior to Puppet 3.6.0.
