### PR TITLE
(PUP-1988) Remove permissions should log

### DIFF
--- a/lib/puppet/provider/acl/windows/base.rb
+++ b/lib/puppet/provider/acl/windows/base.rb
@@ -61,7 +61,7 @@ class Puppet::Provider::Acl
         end
 
         def get_ace_rights_from_mask(ace)
-          #todo: check that this is a file type and respond appropriately
+          #todo v2 check that this is a file type and respond appropriately
           rights = []
           return rights if ace.nil?
           mask_specific_remainder = ace.mask
@@ -174,13 +174,23 @@ class Puppet::Provider::Acl
         end
         module_function :get_ace_propagation
 
-        def are_permissions_insync?(current_permissions, specified_permissions, should_purge = false)
-          return false if current_permissions.nil? && !specified_permissions.nil?
+        def are_permissions_insync?(current_permissions, specified_permissions, purge_value = :false)
+          return false if current_permissions.nil? && !specified_permissions.nil? && purge_value != :listed_permissions
 
-          current_local_permissions = current_permissions.select { |p| !p.is_inherited? }
+          purge_value = purge_value.to_s.downcase.to_sym unless purge_value.is_a?(Symbol)
+          should_purge = purge_value == :true
+          remove_permissions = purge_value == :listed_permissions
+          if current_permissions.nil?
+            current_local_permissions = []
+          else
+            current_local_permissions = current_permissions.select { |p| !p.is_inherited? }
+          end
 
           if should_purge
             current_local_permissions == specified_permissions
+          elsif remove_permissions
+            return true if specified_permissions.nil?
+            (specified_permissions & current_local_permissions) == []
           else
             return true if specified_permissions.nil?
 
@@ -291,7 +301,6 @@ class Puppet::Provider::Acl
 
         def sync_aces(current_dacl, should_aces, should_purge = false, remove_permissions = false)
           unless remove_permissions
-          #if @resource[:ensure] != :absent
             return should_aces if should_purge
 
             current_dacl.each do |ace|
@@ -409,37 +418,6 @@ class Puppet::Provider::Acl
 
           # flush out the cached sd
           get_security_descriptor(REFRESH_SD)
-        end
-
-        def evaluate_destroy(resource)
-          status = Puppet::Resource::Status.new(resource)
-          if Puppet::Transaction::ResourceHarness.instances == nil || Puppet::Transaction::ResourceHarness.instances.count == 0
-            Puppet.warning("ACL is unable to report change to permissions due to not able to access the resource harness. Please check to see that permissions changes were successful where applied if there are no reported errors.")
-            self.permissions = @resource[:permissions]
-            return
-          end
-
-          harness = Puppet::Transaction::ResourceHarness.instances.first
-
-          begin
-            context = Puppet::Transaction::ResourceHarness::ResourceApplicationContext.from_resource(resource, status)
-            ensure_param = resource.parameter(:ensure)
-            resource.properties.each do |param|
-              next if param == ensure_param
-              harness.sync_if_needed_public(param, context)
-            end
-
-            if status.changed? && ! resource.noop?
-              harness.cache(resource, :synced, Time.now)
-              resource.flush if resource.respond_to?(:flush)
-            end
-          rescue => detail
-            status.failed_because(detail)
-          ensure
-            status.evaluation_time = Time.now - status.time
-          end
-
-          harness.transaction.report.add_resource_status(status)
         end
       end
     end

--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -40,7 +40,6 @@ Puppet::Type.newtype(:acl) do
     Minimally expressed sample usage:
 
       acl { 'c:/tempperms':
-        ensure      => present,
         permissions => [
          { identity => 'Administrator', rights => ['full'] },
          { identity => 'Users', rights => ['read','execute'] }
@@ -54,7 +53,6 @@ Puppet::Type.newtype(:acl) do
     Fully expressed sample usage:
 
       acl { 'c:/tempperms':
-        ensure      => present,
         target      => 'c:/tempperms',
         target_type => 'file',
         purge       => 'false',
@@ -79,14 +77,12 @@ Puppet::Type.newtype(:acl) do
     Manage same ACL resource multiple acls sample usage:
 
       acl { 'c:/tempperms':
-        ensure      => present,
         permissions => [
          { identity => 'Administrator', rights => ['full'] }
        ],
       }
 
       acl { 'tempperms_Users':
-        ensure      => present,,
         target      => 'c:/tempperms',
         permissions => [
          { identity => 'Users', rights => ['read','execute'] }
@@ -96,7 +92,6 @@ Puppet::Type.newtype(:acl) do
     Removing upstream inheritance with purge sample usage:
 
       acl { 'c:/tempperms':
-        ensure      => present,
         purge       => 'true',
         permissions => [
          { identity => 'Administrators', rights => ['full'] },
@@ -119,8 +114,6 @@ Puppet::Type.newtype(:acl) do
       self[:target] = self[:name]
     end
   end
-
-  ensurable
 
   newparam(:name) do
     desc "The name of the acl resource. Used for uniqueness. Will set
@@ -154,14 +147,16 @@ Puppet::Type.newtype(:acl) do
     defaultto(:file)
   end
 
-  newparam(:purge, :boolean => true) do
+  newparam(:purge) do
     desc "Purge specifies whether to remove other explicit permissions
       if not specified in the permissions set. This doesn't do anything
       with permissions inherited from parents (to remove those you should
       combine `purge => 'false', inherit_parent_permissions => 'false'`.
+      This also allows you to ensure the permissions listed are not on
+      the ACL with `purge => listed_permissions`.
       The default is false."
-    newvalues(:true, :false)
-    defaultto(false)
+    newvalues(:true, :false, :listed_permissions)
+    defaultto(:false)
   end
 
   newproperty(:permissions, :array_matching => :all) do

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -127,7 +127,6 @@ if Puppet::Util::Platform.windows?
     end
   end
 
-
   require 'puppet/util/windows/security'
   # PUP-2100 - https://tickets.puppetlabs.com/browse/PUP-2100
   # backporting that fix to earlier versions of Puppet.
@@ -175,7 +174,7 @@ if Puppet::Util::Platform.windows?
                         add_access_denied_ace(acl, ace.mask, ace.sid, ace.flags)
                       else
                         raise "We should never get here"
-                      # TODO: this should have been a warning in an earlier commit
+                        # this should have been a warning in an earlier commit
                     end
                   end
 
@@ -199,27 +198,4 @@ if Puppet::Util::Platform.windows?
       end
     end
   end
-
-  if Puppet.version < '3.6.0'
-    class Puppet::Transaction
-      class ResourceHarness
-        # overriding the current initializer method so we can
-        # add the instance to instances
-        def initialize(transaction)
-          @transaction = transaction
-          @@instances = []
-          @@instances << self
-        end
-
-        def self.instances
-          @@instances
-        end
-
-        def sync_if_needed_public(param, context)
-          sync_if_needed(param, context)
-        end
-      end
-    end
-  end
-
 end

--- a/spec/unit/provider/acl/windows_spec.rb
+++ b/spec/unit/provider/acl/windows_spec.rb
@@ -475,45 +475,90 @@ describe Puppet::Type.type(:acl).provider(:windows), :if => Puppet.features.micr
       context "when purge=>true" do
         it "should return true for Administrators and specifying Administrators with same permissions" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
-          provider.are_permissions_insync?([admins], [admins], true).must be_true
+          provider.are_permissions_insync?([admins], [admins], :true).must be_true
         end
 
         it "should return true for Administrators and specifying Administrators even if one specifies sid and other non-required information" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']}, provider)
           admin2 = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full'], 'id'=>"S-1-5-32-544", 'mask'=>::Windows::File::GENERIC_ALL, 'is_inherited'=>false}, provider)
-          provider.are_permissions_insync?([admins], [admin2], true).must be_true
+          provider.are_permissions_insync?([admins], [admin2], :true).must be_true
         end
 
         it "should return false for Administrators and specifying Administrators when more current permissions exist than are specified" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
           admin = Puppet::Type::Acl::Ace.new({'identity'=>'Administrator', 'rights'=>['full']})
-          provider.are_permissions_insync?([admin,admins], [admin], true).must be_false
+          provider.are_permissions_insync?([admin,admins], [admin], :true).must be_false
         end
 
         it "should return false for Administrators and specifying Administrators when more permissions are specified than exist" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
           admin = Puppet::Type::Acl::Ace.new({'identity'=>'Administrator', 'rights'=>['full']})
-          provider.are_permissions_insync?([admin], [admin,admins], true).must be_false
+          provider.are_permissions_insync?([admin], [admin,admins], :true).must be_false
         end
 
         it "should return false for nil and specifying Administrators" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
-          provider.are_permissions_insync?(nil, [admins], true).must be_false
+          provider.are_permissions_insync?(nil, [admins], :true).must be_false
         end
 
         it "should return false for Administrators and specifying nil" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
-          provider.are_permissions_insync?([admins], nil, true).must be_false
+          provider.are_permissions_insync?([admins], nil, :true).must be_false
         end
 
         it "should return false for Administrators and specifying []" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
-          provider.are_permissions_insync?([admins], [], true).must be_false
+          provider.are_permissions_insync?([admins], [], :true).must be_false
         end
 
         it "should return false for [] and specifying Administrators" do
           admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
-          provider.are_permissions_insync?([], [admins], true).must be_false
+          provider.are_permissions_insync?([], [admins], :true).must be_false
+        end
+      end
+
+      context "when purge=>listed_permissions" do
+        it "should return false for Administrators and specifying Administrators with same permissions" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          provider.are_permissions_insync?([admins], [admins], :listed_permissions).must be_false
+        end
+
+        it "should return false for Administrators and specifying Administrators even if one specifies sid and other non-required information" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']}, provider)
+          admin2 = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full'], 'id'=>"S-1-5-32-544", 'mask'=>::Windows::File::GENERIC_ALL, 'is_inherited'=>false}, provider)
+          provider.are_permissions_insync?([admins], [admin2], :listed_permissions).must be_false
+        end
+
+        it "should return false for Administrators and specifying Administrators when more current permissions exist than are specified" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          admin = Puppet::Type::Acl::Ace.new({'identity'=>'Administrator', 'rights'=>['full']})
+          provider.are_permissions_insync?([admin,admins], [admin], :listed_permissions).must be_false
+        end
+
+        it "should return false for Administrators and specifying Administrators when more permissions are specified than exist" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          admin = Puppet::Type::Acl::Ace.new({'identity'=>'Administrator', 'rights'=>['full']})
+          provider.are_permissions_insync?([admin], [admin,admins], :listed_permissions).must be_false
+        end
+
+        it "should return true for nil and specifying Administrators" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          provider.are_permissions_insync?(nil, [admins], :listed_permissions).must be_true
+        end
+
+        it "should return true for Administrators and specifying nil" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          provider.are_permissions_insync?([admins], nil, :listed_permissions).must be_true
+        end
+
+        it "should return true for Administrators and specifying []" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          provider.are_permissions_insync?([admins], [], :listed_permissions).must be_true
+        end
+
+        it "should return true for [] and specifying Administrators" do
+          admins = Puppet::Type::Acl::Ace.new({'identity'=>'Administrators', 'rights'=>['full']})
+          provider.are_permissions_insync?([], [admins], :listed_permissions).must be_true
         end
       end
     end

--- a/spec/unit/type/acl_spec.rb
+++ b/spec/unit/type/acl_spec.rb
@@ -306,7 +306,7 @@ describe Puppet::Type.type(:acl) do
 
   context "parameter :purge" do
     it "should default to nil" do
-      resource[:purge].must be_nil
+      resource[:purge].must == :false
     end
 
     it "should accept true" do
@@ -315,6 +315,26 @@ describe Puppet::Type.type(:acl) do
 
     it "should accept false" do
       resource[:purge] = false
+    end
+
+    it "should accept 'true'" do
+      resource[:purge] = 'true'
+    end
+
+    it "should accept 'false'" do
+      resource[:purge] = 'false'
+    end
+
+    it "should accept :true" do
+      resource[:purge] = :true
+    end
+
+    it "should accept :false" do
+      resource[:purge] = :false
+    end
+
+    it "should accept :listed_permissions" do
+      resource[:purge] = :listed_permissions
     end
 
     it "should reject non-boolean values" do

--- a/tests/hiera.pp
+++ b/tests/hiera.pp
@@ -19,7 +19,6 @@ file {'c:/temp':
 #}
 
 acl { 'c:\temp':
-  ensure      => present,
   permissions => [
     {
       identity => 'Administrators',
@@ -32,7 +31,6 @@ acl { 'c:\temp':
 
 acl { 'temp_dir_module_name':
   target      => 'c:/temp',
-  ensure      => present,
   permissions => [
     {
       identity => 'bob',
@@ -47,7 +45,6 @@ acl { 'temp_dir_module_name':
 
 acl { 'temp_dir_module2_name':
   target      => 'c:/temp',
-  ensure      => present,
   permissions => [
     {
       identity => 'bill',

--- a/tests/hieradata/common.yaml
+++ b/tests/hieradata/common.yaml
@@ -2,7 +2,6 @@
 acls:
   tempdir:
     target: 'C:\temp'
-    ensure: present
     permissions:
       - identity: 'tim'
         rights:
@@ -16,7 +15,6 @@ acls:
           - execute
   dir2:
     target: 'C:\temp'
-    ensure: present
     permissions:
       - identity: 'tim'
         rights:

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -13,7 +13,7 @@ include acl
 file { ['c:/tempperms',
    'c:/tempperms/minimal',
    'c:/tempperms/full',
-   'c:/tempperms/multiuser',
+   'c:/tempperms/fqdn_sid',
    'c:/tempperms/protected',
    'c:/tempperms/protected_purge',
    'c:/tempperms/inheritance',
@@ -21,14 +21,12 @@ file { ['c:/tempperms',
    'c:/tempperms/deny',
    'c:/tempperms/same_user',
    'c:/tempperms/rights_ordering',
-   'c:/tempperms/identities',
    'c:/tempperms/mask_specific',
-   'c:/tempperms/absent']:
+   'c:/tempperms/remove']:
   ensure => directory,
 }
 
 acl { 'c:/tempperms/minimal':
-  ensure      => present,
   permissions => [
    { identity => 'Administrator', rights => ['full'] },
    { identity => 'Users', rights => ['read','execute'] }
@@ -49,7 +47,6 @@ acl { 'c:/tempperms/minimal':
 
 # same as minimal but fully expressed
 acl { 'c:/tempperms/full':
-  ensure      => present,
   target      => 'c:/tempperms/full',
   target_type => 'file',
   purge       => 'false',
@@ -74,34 +71,29 @@ acl { 'c:/tempperms/full':
 #     NT AUTHORITY\Authenticated Users:(I)(OI)(CI)(IO)(M)
 
 
-acl { 'c:/tempperms/multiuser':
-  ensure      => present,
+acl { 'c:/tempperms/fqdn_sid':
   permissions => [
-   { identity => 'Administrators', rights => ['full'] },
-   { identity => 'Administrator', rights => ['write'] },
-   { identity => 'Users', rights => ['write','execute'] },
-   { identity => 'Everyone', rights => ['execute'] },
-   { identity => 'Authenticated Users', rights => ['full'] }
+   { identity => 'S-1-5-32-544', rights => ['full'] },
+   { identity => 'NT AUTHORITY\SYSTEM', rights => ['write'] },
+   { identity => 'BUILTIN\Users', rights => ['write','execute'] },
+   { identity => 'Everyone', rights => ['execute'] }
   ],
 }
 
-#C:\tempperms>icacls multiuser
-#multiuser BUILTIN\Administrators:(OI)(CI)(F)
-#          WIN-QR952GIDHVE\Administrator:(OI)(CI)(W,Rc)
-#          BUILTIN\Users:(OI)(CI)(W,Rc,X,RA)
-#          Everyone:(OI)(CI)(Rc,S,X,RA)
-#          NT AUTHORITY\Authenticated Users:(OI)(CI)(F)
-#          BUILTIN\Administrators:(I)(F)
-#          BUILTIN\Administrators:(I)(OI)(CI)(IO)(F)
-#          NT AUTHORITY\SYSTEM:(I)(F)
-#          NT AUTHORITY\SYSTEM:(I)(OI)(CI)(IO)(F)
-#          BUILTIN\Users:(I)(OI)(CI)(RX)
-#          NT AUTHORITY\Authenticated Users:(I)(M)
-#          NT AUTHORITY\Authenticated Users:(I)(OI)(CI)(IO)(M)
-
+#C:\tempperms>icacls fqdn_sid
+#fqdn_sid BUILTIN\Administrators:(OI)(CI)(F)
+#         NT AUTHORITY\SYSTEM:(OI)(CI)(W,Rc)
+#         BUILTIN\Users:(OI)(CI)(W,Rc,X,RA)
+#         Everyone:(OI)(CI)(Rc,S,X,RA)
+#         BUILTIN\Administrators:(I)(F)
+#         BUILTIN\Administrators:(I)(OI)(CI)(IO)(F)
+#         NT AUTHORITY\SYSTEM:(I)(F)
+#         NT AUTHORITY\SYSTEM:(I)(OI)(CI)(IO)(F)
+#         BUILTIN\Users:(I)(OI)(CI)(RX)
+#         NT AUTHORITY\Authenticated Users:(I)(M)
+#         NT AUTHORITY\Authenticated Users:(I)(OI)(CI)(IO)(M)
 
 acl { 'c:/tempperms/protected':
-  ensure      => present,
   permissions => [
    { identity => 'Administrators', rights => ['full'] },
    { identity => 'Users', rights => ['full'] }
@@ -110,7 +102,6 @@ acl { 'c:/tempperms/protected':
 }
 
 acl { 'tempperms_protected':
-  ensure      => present,
   target      => 'c:/tempperms/protected',
   permissions => [
    { identity => 'Administrator', rights => ['modify'] }
@@ -131,7 +122,6 @@ acl { 'tempperms_protected':
 
 
 acl { 'c:/tempperms/protected_purge':
-  ensure      => present,
   purge       => 'true',
   permissions => [
    { identity => 'Administrators', rights => ['full'] },
@@ -146,7 +136,6 @@ acl { 'c:/tempperms/protected_purge':
 
 
 acl { 'c:/tempperms/inheritance':
-  ensure      => present,
   purge       => 'true',
   permissions => [
    { identity => 'SYSTEM', rights => ['full'], child_types => 'all' },
@@ -164,7 +153,6 @@ acl { 'c:/tempperms/inheritance':
 
 
 acl { 'c:/tempperms/propagation':
-  ensure      => present,
   purge       => 'true',
   permissions => [
    { identity => 'Administrators', rights => ['modify'], affects => 'all' },
@@ -216,16 +204,13 @@ file { ['c:/tempperms/propagation/child_object.txt',
 
 
 acl { 'c:/tempperms/deny':
-  ensure      => present,
   permissions => [
-   { identity => 'SYSTEM', rights => ['full'], type=> 'deny', affects => 'self_only' }
+   { identity => 'SYSTEM', rights => ['full'], type=> 'deny' }
   ],
 }
 
-# BUG: Deny does not inherit by default?
-
 #C:\tempperms>icacls deny
-#deny  NT AUTHORITY\SYSTEM:(N)
+#deny  NT AUTHORITY\SYSTEM:(I)(N)
 #      BUILTIN\Administrators:(I)(F)
 #      BUILTIN\Administrators:(I)(OI)(CI)(IO)(F)
 #      NT AUTHORITY\SYSTEM:(I)(F)
@@ -236,7 +221,6 @@ acl { 'c:/tempperms/deny':
 
 
 acl { 'c:/tempperms/same_user':
-  ensure      => present,
   purge       => 'true',
   permissions => [
    #{ identity => 'SYSTEM', rights => ['modify'], type=> 'deny', child_types => 'none' },
@@ -275,7 +259,6 @@ acl { 'c:/tempperms/same_user':
 
 
 acl { 'c:/tempperms/rights_ordering':
-  ensure      => present,
   purge       => 'true',
   permissions => [
    { identity => 'SYSTEM', rights => ['execute','read'] },
@@ -294,25 +277,7 @@ acl { 'c:/tempperms/rights_ordering':
 #                WIN-QR952GIDHVE\Administrator:(OI)(CI)(M)
 
 
-acl { 'c:/tempperms/identities':
-  ensure      => present,
-  purge       => 'true',
-  permissions => [
-   { identity => 'NT AUTHORITY\SYSTEM', rights => ['modify'] },
-   { identity => 'BUILTIN\Users', rights => ['read','execute'] },
-   { identity => 'S-1-5-32-544', rights => ['full'] }
-  ],
-  inherit_parent_permissions => 'false',
-}
-
-#C:\tempperms>icacls identities
-#identities NT AUTHORITY\SYSTEM:(OI)(CI)(M)
-#           BUILTIN\Users:(OI)(CI)(RX)
-#           BUILTIN\Administrators:(OI)(CI)(F)
-
-
 acl { 'c:/tempperms/mask_specific':
-  ensure      => present,
   purge       => 'true',
   permissions => [
    { identity => 'Administrators', rights => ['full'] }, #full is same as - 2032127 aka 0x1f01ff
@@ -330,8 +295,7 @@ acl { 'c:/tempperms/mask_specific':
 #              WIN-QR952GIDHVE\Administrator:(OI)(CI)(Rc,S,RA,WA)
 
 
-acl { 'c:/tempperms/absent':
-  ensure      => present,
+acl { 'c:/tempperms/remove':
   purge       => 'true',
   permissions => [
    { identity => 'Administrators', rights => ['full'] },
@@ -343,19 +307,18 @@ acl { 'c:/tempperms/absent':
   inherit_parent_permissions => 'false',
 }
 
-acl { 'remove_tempperms/absent':
-  ensure      => absent,
-  target      => 'c:/tempperms/absent',
-  purge       => 'true',
+acl { 'remove_tempperms/remove':
+  target      => 'c:/tempperms/remove',
+  purge       => 'listed_permissions',
   permissions => [
    { identity => 'Administrator', rights => ['write'] },
    { identity => 'Authenticated Users', rights => ['full'] }
   ],
   inherit_parent_permissions => 'false',
-  require     => Acl['c:/tempperms/absent'],
+  require     => Acl['c:/tempperms/remove'],
 }
 
-#C:\tempperms>icacls absent
-#absent BUILTIN\Administrators:(OI)(CI)(F)
+#C:\tempperms>icacls remove
+#remove BUILTIN\Administrators:(OI)(CI)(F)
 #       BUILTIN\Users:(OI)(CI)(W,Rc,X,RA)
 #       Everyone:(OI)(CI)(Rc,S,X,RA)


### PR DESCRIPTION
This started out as a way to ensure permissions changes would log 
when `ensure=>absent` and ended with removing ensurable with 
`purge=>listed_permissions` instead to remove permissions.
