### PR TITLE
(FM-1161) Adjust file permission defaults

### DIFF
--- a/spec/integration/provider/acl/windows_spec.rb
+++ b/spec/integration/provider/acl/windows_spec.rb
@@ -290,6 +290,19 @@ describe Puppet::Type.type(:acl).provider(:windows), :if => Puppet.features.micr
         perms_not_empty.must == true
       end
 
+      it "should handle file permissions" do
+        file_path = File.join(resource[:target],"file.txt")
+        FileUtils.touch(file_path)
+        resource[:target] = file_path
+        permissions = [
+            Puppet::Type::Acl::Ace.new({'identity' => 'Everyone','rights' => ['full']}, provider)
+        ]
+        resource[:purge] = true
+        provider.inherit_parent_permissions = :false
+
+        set_perms(permissions).must == permissions
+      end
+
       it "should handle setting ace inheritance" do
         permissions = [
             Puppet::Type::Acl::Ace.new({'identity' => 'Administrators','rights' => ['full'], 'child_types' => 'containers'}, provider),

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -322,3 +322,17 @@ acl { 'remove_tempperms/remove':
 #remove BUILTIN\Administrators:(OI)(CI)(F)
 #       BUILTIN\Users:(OI)(CI)(W,Rc,X,RA)
 #       Everyone:(OI)(CI)(Rc,S,X,RA)
+
+file {'c:/tempperms/file.txt':
+  ensure => file,
+  content => 'yup',
+}
+
+acl { 'c:/tempperms/file.txt':
+  purge       => true,
+  permissions => [
+   { identity => 'Administrators', rights => ['full'] },
+   { identity => 'Everyone', rights => ['read'] }
+  ],
+  inherit_parent_permissions => false,
+}


### PR DESCRIPTION
A file doesn't have inheritance, so it should be
`affects => 'self_only'` when the target path is a file
and not a directory.  Without this users would need
to ensure they always specifiy `affects => 'self_only'`
for every identity in the acl resource when targeting
a file and not a directory.
