### PR TITLE
(PUP-2336) Is inherited should not be allowed in aces

### DIFF
--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -189,11 +189,11 @@ Puppet::Type.newtype(:acl) do
       if value.nil? || value.empty?
         raise ArgumentError, "A non-empty permissions must be specified."
       end
-      if value['inherited']
+      if value['is_inherited']
         raise ArgumentError,
          "Puppet can not manage inherited ACEs.
          If you used puppet resource acl to build your manifest, please remove
-         any inherited => true entries in permissions when adding the resource
+         any is_inherited => true entries in permissions when adding the resource
          to the manifest.
          Reference: #{value.inspect}"
       end

--- a/spec/unit/type/acl_spec.rb
+++ b/spec/unit/type/acl_spec.rb
@@ -475,7 +475,7 @@ describe Puppet::Type.type(:acl) do
 
     it "should not allow inherited aces in manifests" do
       expect {
-        resource[:permissions] = {'identity' =>'bob','rights'=>['full'],'inherited'=>'true'}
+        resource[:permissions] = {'identity' =>'bob','rights'=>['full'],'is_inherited'=>'true'}
       }.to raise_error(Puppet::ResourceError, /Puppet can not manage inherited ACEs/)
     end
 


### PR DESCRIPTION
This fixes incorrect usage of the ace['inherited'] to ace['is_inherited'].
Without this fix folks can use puppet resource and copy the inherited
items into the manifest and get some interesting results.
