### PR TITLE
(PUP-2338) fail on symbolic link

### DIFF
--- a/lib/puppet/provider/acl/windows.rb
+++ b/lib/puppet/provider/acl/windows.rb
@@ -51,6 +51,16 @@ Puppet::Type.type(:acl).provide :windows do
     end
   end
 
+  def validate
+    case @resource[:target_type]
+      when :file
+        # Target may not be set, this is called prior to initialize
+        if Puppet::Util::Windows::File.symlink?(@resource[:target] || @resource[:name])
+          raise Puppet::ResourceError, "Puppet cannot manage ACLs of symbolic links (symlinks) on Windows. Resource target '#{@resource[:target] || @resource[:name]}' is a symlink."
+        end
+    end
+  end
+
   def permissions
     get_current_permissions
   end

--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -334,6 +334,10 @@ Puppet::Type.newtype(:acl) do
     if self[:permissions] == []
       raise ArgumentError, "Value for permissions should be an array with at least one element specified."
     end
+
+    if provider.respond_to?(:validate)
+      provider.validate
+    end
   end
 
   autorequire(:file) do

--- a/spec/integration/provider/acl/windows_spec.rb
+++ b/spec/integration/provider/acl/windows_spec.rb
@@ -60,6 +60,34 @@ describe Puppet::Type.type(:acl).provider(:windows), :if => Puppet.features.micr
     }.to raise_error(Exception, /Failed to get security descriptor for path/)
   end
 
+  context ":target" do
+    before :each do
+      resource[:target] = set_path('set_target')
+    end
+
+    it "should not allow permissions to be set on directory symlinks (PUP-2338)" do
+      target_path = set_path('symlink_target')
+      resource[:target] = File.expand_path("fake",resource[:target])
+      Puppet::Util::Windows::File.symlink(target_path,resource[:target])
+
+      expect {
+        resource.validate
+      }.to raise_error(Puppet::ResourceError, /Puppet cannot manage ACLs of symbolic links/)
+    end
+
+    it "should not allow permissions to be set on file symlinks (PUP-2338)" do
+      target_path = set_path('symlink_target')
+      file_path = File.join(target_path,"file.txt")
+      FileUtils.touch(file_path)
+      resource[:target] = File.expand_path("fakefile.txt",resource[:target])
+      Puppet::Util::Windows::File.symlink(file_path,resource[:target])
+
+      expect {
+        resource.validate
+      }.to raise_error(Puppet::ResourceError, /Puppet cannot manage ACLs of symbolic links/)
+    end
+  end
+
   context ":owner" do
     before :each do
       resource[:target] = set_path('owner_stuff')


### PR DESCRIPTION
Prior to this if a user specified a symlink as the target of the acl, puppet
would not report an error during application. It would just silently fail.
Since the acl module does not support symlinks so the appropriate
behavior is to throw an error informing the user that symlinks are not
supported.
