### PR TITLE
update Gemfile syntax to work with Ruby oddity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem 'rspec', "~> 2.11.0"
   gem 'mocha', "~> 0.10.5"
   # beaker is not supported to be installed on windows
-  gem 'beaker', ">= 1.9.0" if !RUBY_PLATFORM=~ /win32/
+  gem 'beaker', ">= 1.9.0" unless RUBY_PLATFORM =~ /win32/
   gem 'puppetlabs_spec_helper'
 end
 


### PR DESCRIPTION
Now I believe it does what was intended.

Fun times with Ruby

```
justin$ bundle exec ruby -e 'puts (RUBY_PLATFORM=~ /win32/).class'
NilClass
justin$ bundle exec ruby -e 'puts (!RUBY_PLATFORM=~ /win32/).class'
NilClass
justin$ bundle exec ruby -e 'puts (!!RUBY_PLATFORM=~ /win32/).class'
NilClass
justin$ bundle exec ruby -e 'puts (not RUBY_PLATFORM=~ /win32/).class'
TrueClass
```
