### PR TITLE
install puppet when running against foss

### DIFF
--- a/acceptance/setup/foss_install.rb
+++ b/acceptance/setup/foss_install.rb
@@ -1,6 +1,11 @@
 test_name "Install ACL Module on Master"
 
+step "Install FOSS"
+install_puppet({ :version        =>  ENV['PUPPET_VERSION'] || '3.6.2',
+                 :default_action => 'gem_install'                       })
+
 step "Clone Git Repo on Master"
+on(master, "mkdir -p #{master['distmoduledir']}")
 on(master, "git clone https://github.com/puppetlabs/puppetlabs-acl.git /etc/puppet/modules/acl")
 
 step "Plug-in Sync Each Agent"


### PR DESCRIPTION
Prior to this we weren't install puppet before running the tests on Open Source test runs, now we install whatever version of Puppet is specified in the env var "PUPPPET_VERSION" or fall back to '3.6.2' (the latest at the time of writing). We also accept falling back to a gem install, and make sure that the module dir exists if we do.
