### PR TITLE
(MODULES-1482) Fix Autorequires to only include resource title

### DIFF
--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -382,15 +382,7 @@ Puppet::Type.newtype(:acl) do
     if self[:target] && self[:target_type] == :file
       target_path = File.expand_path(self[:target]).to_s
 
-      # There is a bug with the casing on the volume (c:/ versus C:/)
-      #  causing resources to not be found by the catalog checking
-      #  against lowercase and uppercase corrects that.
-      target_path[0] = target_path[0].downcase
-      unless file_resource = catalog.resource(:file, target_path)
-        target_path[0] = target_path[0].upcase
-        file_resource = catalog.resource(:file, target_path)
-      end
-      required_file << file_resource.to_s if file_resource
+      required_file << target_path
     end
 
     required_file
@@ -407,29 +399,29 @@ Puppet::Type.newtype(:acl) do
 
     if self[:owner]
       if has_account_name_method
-        required_users << "User[#{provider.get_account_name(self[:owner])}]"
+        required_users << "#{provider.get_account_name(self[:owner])}"
       end
 
       # add the unqualified item whether qualified is found or not
-      required_users << "User[#{self[:owner]}]"
+      required_users << "#{self[:owner]}"
     end
 
     if self[:group]
       if has_account_name_method
-        required_users << "User[#{provider.get_account_name(self[:group])}]"
+        required_users << "#{provider.get_account_name(self[:group])}"
       end
 
       # add the unqualified item whether qualified is found or not
-      required_users << "User[#{self[:group]}]"
+      required_users << "#{self[:group]}"
     end
 
     permissions = self[:permissions]
     unless permissions.nil?
       permissions.each do |permission|
         if has_account_name_method
-          required_users << "User[#{provider.get_account_name(permission.identity)}]"
+          required_users << "#{provider.get_account_name(permission.identity)}"
         end
-        required_users << "User[#{permission.identity}]"
+        required_users << "#{permission.identity}"
       end
     end
 
@@ -447,29 +439,29 @@ Puppet::Type.newtype(:acl) do
 
     if self[:owner]
       if has_account_group_method
-        required_groups << "Group[#{provider.get_group_name(self[:owner])}]"
+        required_groups << "#{provider.get_group_name(self[:owner])}"
       end
 
       # add the unqualified item whether qualified is found or not
-      required_groups << "Group[#{self[:owner]}]"
+      required_groups << "#{self[:owner]}"
     end
 
     if self[:group]
       if has_account_group_method
-        required_groups << "Group[#{provider.get_group_name(self[:group])}]"
+        required_groups << "#{provider.get_group_name(self[:group])}"
       end
 
       # add the unqualified item whether qualified is found or not
-      required_groups << "Group[#{self[:group]}]"
+      required_groups << "#{self[:group]}"
     end
 
     permissions = self[:permissions]
     unless permissions.nil?
       permissions.each do |permission|
         if has_account_group_method
-          required_groups << "Group[#{provider.get_group_name(permission.identity)}]"
+          required_groups << "#{provider.get_group_name(permission.identity)}"
         end
-        required_groups << "Group[#{permission.identity}]"
+        required_groups << "#{permission.identity}"
       end
     end
 

--- a/spec/unit/type/acl_spec.rb
+++ b/spec/unit/type/acl_spec.rb
@@ -256,6 +256,16 @@ describe Puppet::Type.type(:acl) do
         reqs[0].target.must == resource
       end
 
+      def test_should_not_set_autorequired_file(resource_path,file_path)
+        resource[:target] = resource_path
+        dir = Puppet::Type.type(:file).new(:path => file_path)
+        catalog.add_resource resource
+        catalog.add_resource dir
+        reqs = resource.autorequire
+
+        reqs.must be_empty
+      end
+
       it "should autorequire an existing file resource when acl.target matches file.path exactly" do
         test_should_set_autorequired_file('c:/temp',"c:/temp")
       end
@@ -272,12 +282,12 @@ describe Puppet::Type.type(:acl) do
         test_should_set_autorequired_file('C:/temp',"C:/temp")
       end
 
-      it "should autorequire an existing file resource when acl.target volume is uppercase C and file.path is lowercase c" do
-        test_should_set_autorequired_file('C:/temp',"c:/temp")
+      it "should not autorequire an existing file resource when acl.target volume is uppercase C and file.path is lowercase c" do
+        test_should_not_set_autorequired_file('C:/temp',"c:/temp")
       end
 
-      it "should autorequire an existing file resource when acl.target volume is lowercase C and file.path is uppercase C" do
-        test_should_set_autorequired_file('c:/temp',"C:/temp")
+      it "should not autorequire an existing file resource when acl.target volume is lowercase C and file.path is uppercase C" do
+        test_should_not_set_autorequired_file('c:/temp',"C:/temp")
       end
 
       it "should not autorequire an existing file resource when it is different than acl.target" do


### PR DESCRIPTION
Previously the acl module was using autorequires that include the resource name
and type, like `Group['None']`. With PUP-3177 (first available in Puppet 3.7.1
and in PE 3.7.0), this now results in invalid calls to `Puppet::Resource`.

Specifying the resource type is incorrect and not a best practice (it
is already handled by `autorequire(:type)` at the start of each of the
autorequire methods.

This adjusts the autorequires to follow the correct practice of only including
the resource title.

This also adjusts file autorequires to greatly simplify the logic and reduce
the extra call to `catalog.resource` which is called later by
`Puppet::Resource`. The reduction in logic means the file resource name case
needs to match exactly, but that is in line with how other requires should be
specified.
