### PR TITLE
Experimental - puppet-agent testing support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,12 @@ task :beaker_git, [:hosts, :tests] do |t, args|
   system(build_command(args))
 end
 
+desc 'Run Beaker Puppet-Agent tests'
+Beaker::Tasks::RakeTask.new("beaker:test:puppet-agent", :hosts) do |t,args|
+  t.type = 'puppet-agent'
+  t.hosts = args[:hosts]
+end
+
 def build_command(args)
   cmd_parts = []
   cmd_parts << "beaker"

--- a/acceptance/.beaker-puppet-agent.cfg
+++ b/acceptance/.beaker-puppet-agent.cfg
@@ -1,0 +1,9 @@
+{
+  :type            => 'aio',
+  :pre_suite       => ['./acceptance/setup/puppet-agent_install.rb'],
+  :hosts_file      => './acceptance/config/windows-aio-2012r2-x86_64.cfg',
+  :debug           => true,
+  :tests           => './acceptance/tests',
+  :keyfile         => '~/.ssh/id_rsa-acceptance',
+  :timeout         => 6000
+}

--- a/acceptance/config/windows-aio-2012r2-x86_64.cfg
+++ b/acceptance/config/windows-aio-2012r2-x86_64.cfg
@@ -1,0 +1,32 @@
+HOSTS:
+  debian6:
+    roles:
+      - master
+      - agent
+    platform: debian-6-i386
+    template: debian-6-i386
+    hypervisor: vcloud
+  w2012r2-puppetx64:
+    ruby_arch: x64
+    roles:
+      - agent
+      - default
+    platform: windows-2012r2-x86_64
+    template: win-2012r2-x86_64
+    hypervisor: vcloud
+  w2012r2-puppetx86:
+    ruby_arch: x86
+    roles:
+      - agent
+    platform: windows-2012r2-x86_64
+    template: win-2012r2-x86_64
+    hypervisor: vcloud
+CONFIG:
+  type: aio
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  pe_dir: http://neptune.puppetlabs.lan/3.3/ci-ready/

--- a/acceptance/setup/puppet-agent_install.rb
+++ b/acceptance/setup/puppet-agent_install.rb
@@ -1,0 +1,23 @@
+test_name "Install Puppet Agent"
+
+version = ENV['PUPPET_AGENT_VERSION'] || '0.9.1'
+download_url = ENV['WIN_DOWNLOAD_URL'] || 'http://builds.puppetlabs.lan/'
+proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
+hosts.each do |host|
+  if host['platform'] =~ /windows/
+    step "Install foss from MSI"
+    install_puppetagent_dev_repo(host,
+                            {
+                                :dev_builds_url => download_url,
+                                :version => version
+                            })
+
+    on host, "mkdir -p #{host['distmoduledir']}/acl"
+    result = on host, "echo #{host['distmoduledir']}/acl"
+    target = result.raw_output.chomp
+    step "Install ACL to host"
+    %w(lib manifests metadata.json).each do |file|
+      scp_to host, "#{proj_root}/#{file}", "#{target}"
+    end
+  end
+end


### PR DESCRIPTION
3 node setup with 1 debian master, 2 Windows nodes with 32-bit and 64-bit
Puppet installed

2 failures are generated

acceptance/tests/parameter_target/negative/negative_acl_blank_target.rb
generates a failure based on a hardcoded error message that's changed
in future parser

acceptance/tests/basic_functionality/negative/negative_acl_on_linux.rb
generates a failure because the master doesn't have a Linux AIO
package installed and hence doesn't have puppet in path