### PR TITLE
(MODULES-1999) Add AppVeyor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,14 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "puppet", *location_for(ENV['PUPPET_LOCATION'] || '~> 3.7.0')
-gem "facter", *location_for(ENV['FACTER_LOCATION'] || '~> 2.0')
-gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '~> 1.0')
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion,  :require => false
+else
+  gem 'puppet', *location_for(ENV['PUPPET_LOCATION'] || '~> 3')
+end
+
+gem "facter", *location_for(ENV['FACTER_LOCATION'] || '>= 1')
+gem "hiera", *location_for(ENV['HIERA_LOCATION'] || '>= 1')
 
 beaker_version = ENV['BEAKER_VERSION']
 group :development, :test do
@@ -31,18 +36,18 @@ end
 
 # see http://projects.puppetlabs.com/issues/21698
 platforms :mswin, :mingw do
-  gem "ffi", "1.9.0", :require => false
+  gem "ffi", "~> 1.9.0", :require => false
   gem "sys-admin", "~> 1.5.6", :require => false
   gem "win32-api", "~> 1.4.8", :require => false
-  gem "win32-dir", "~> 0.3.7", :require => false
-  gem "win32-eventlog", "~> 0.5.3", :require => false
-  gem "win32-process", "~> 0.6.5", :require => false
-  gem "win32-security", "~> 0.1.4", :require => false
-  gem "win32-service", "~> 0.7.2", :require => false
-  gem "win32-taskscheduler", "~> 0.2.2", :require => false
-  gem "win32console", "~> 1.3.2", :require => false
-  gem "windows-api", "~> 0.4.2", :require => false
-  gem "windows-pr", "~> 1.2.1", :require => false
+  gem "win32-dir", "~> 0.3", :require => false
+  gem "win32-eventlog", "~> 0.5", :require => false
+  gem "win32-process", "~> 0.6", :require => false
+  gem "win32-security", "~> 0.1", :require => false
+  gem "win32-service", "~> 0.7", :require => false
+  gem "win32-taskscheduler", "~> 0.2", :require => false
+  gem "win32console", "~> 1.3", :require => false
+  gem "windows-api", "~> 0.4", :require => false
+  gem "windows-pr", "~> 1.2", :require => false
   gem "minitar", "~> 0.5.4", :require => false
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+version: 1.1.x.{build}
+skip_commits:
+  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
+clone_depth: 10
+init:
+- SET
+- 'mkdir C:\ProgramData\PuppetLabs\code && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\facter && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
+- 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
+environment:
+  matrix:
+  - PUPPET_GEM_VERSION: 3.4.3
+    RUBY_VER: 193
+  - PUPPET_GEM_VERSION: 3.7.5
+    RUBY_VER: 193
+  - PUPPET_GEM_VERSION: 3.7.5
+    RUBY_VER: 200-x64
+  - PUPPET_GEM_VERSION: 4.0.0
+    RUBY_VER: 21
+  - PUPPET_GEM_VERSION: 4.0.0
+    RUBY_VER: 21-x64
+matrix:
+  fast_finish: true
+install:
+- SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+- gem install bundler --quiet --no-ri --no-rdoc
+- bundle install --jobs 4 --retry 2 --without development
+- type Gemfile.lock
+build_script:
+- 'bundle exec puppet apply -e "user {''Administrator'': ensure=>present, password => ''Th!s1sS#cur3@@@2129021'', groups=>[''Administrators''],}" && exit 0'
+test_script:
+- bundle exec puppet -V
+- ruby -v
+- bundle exec rspec spec/unit spec/integration -fd -b
+notifications:
+- provider: Email
+  to:
+  - nobody@nowhere.com
+  on_build_success: false
+  on_build_failure: false
+  on_build_status_changed: false


### PR DESCRIPTION
Add AppVeyor to acl module.

- Matrix - Run against several supported versions of Puppet
- Set fast finish on the matrix to fail immediately if one cell fails
- Notify the Ruby / Puppet versions
- Capture Environment vars / Gemfile.lock contents
- Ensure Administrator - AppVeyor doesn't have an Administrator account by
  default, so put the adminstrator account back for specs to pass
- create top level Puppet data folders - puppet runs on Windows fails until the
  folders exist
- Skip commits that are docs/acceptance tests
- clone only the last 10 commits
- turn off notifications
