### PR TITLE
(maint) puppetlabs_spec_helper ~>0.10.3

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,6 +13,7 @@ Gemfile:
         version: '~>2.14.1'
       - gem: puppet-lint
       - gem: puppetlabs_spec_helper
+        version: '~>0.10.3'
       - gem: puppet_facts
       - gem: mocha
         version: '~>0.10.5'

--- a/Gemfile
+++ b/Gemfile
@@ -26,12 +26,12 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem 'rake',                    :require => false
-  gem 'rspec', '~>2.14.1',       :require => false
-  gem 'puppet-lint',             :require => false
-  gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet_facts',            :require => false
-  gem 'mocha', '~>0.10.5',       :require => false
+  gem 'rake',                                :require => false
+  gem 'rspec', '~>2.14.1',                   :require => false
+  gem 'puppet-lint',                         :require => false
+  gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
+  gem 'puppet_facts',                        :require => false
+  gem 'mocha', '~>0.10.5',                   :require => false
 end
 
 group :system_tests do


### PR DESCRIPTION
Using PSH with versions lower than 0.9.0 results in issues
attempting to symlink on Windows. We'll take the latest
version as the dependency since it has the best fixes
available for cross platform testing.