### PR TITLE
(MAINT) use newer psh version to be able to run the unit tests again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :development do
   gem 'rake',                                :require => false
   gem 'rspec', '~>2.14.1',                   :require => false
   gem 'puppet-lint',                         :require => false
-  gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
+  gem 'puppetlabs_spec_helper', '~>1.0.0',   :require => false
   gem 'puppet_facts',                        :require => false
   gem 'mocha', '~>0.10.5',                   :require => false
 end


### PR DESCRIPTION
Without this, rake spec is failing with `LoadError: cannot load such file -- puppetlabs_spec_helper/rake_tasks` for me.