### PR TITLE
(FM-5039) Install Forge Certs for Acceptance

### DIFF
--- a/acceptance/setup/install.rb
+++ b/acceptance/setup/install.rb
@@ -1,8 +1,12 @@
 require 'beaker/puppet_install_helper'
 
+step 'Install Puppet'
 run_puppet_install_helper
 
-step "Install Module hosts"
+step 'Install Certs'
+install_ca_certs
+
+step 'Install Module'
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
 hosts.each do |host|
   install_dev_puppet_module_on(host, :source => proj_root, :module_name => 'acl')


### PR DESCRIPTION
Install the Forge certs on the SUT for acceptance testing. This enables
installing the module from the module staging forge.

[skip ci]