### PR TITLE
Remove vim line for ruby1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,5 +161,3 @@ end
 if File.exists?(File.join(Dir.home, '.gemfile'))
   eval(File.read(File.join(Dir.home, '.gemfile')), binding)
 end
-
-# vim:ft=ruby


### PR DESCRIPTION
It thinks this is modifying a variable?
```
11:07:18 [!] There was an error parsing `Gemfile`: can't modify frozen String. Bundler cannot continue.
11:07:18 
11:07:18  #  from C:/jenkins/workspace/forge-windows_puppetlabs-acl_intn-module_master/P/3.4.0/R/ruby-1.9.3-p551.1/S/unit-win2012/Gemfile:90
11:07:18  #  -------------------------------------------
11:07:18  #  
11:07:18  >  # vim:ft=ruby
11:07:18  #  #This file is generated by ModuleSync, do not edit.
11:07:18  #  -------------------------------------------
```