### PR TITLE
{DO NOT MERGE}(MODULES-4230) Add support for custom puppet-agent installations

### DIFF
--- a/acceptance/setup/install.rb
+++ b/acceptance/setup/install.rb
@@ -1,7 +1,24 @@
 require 'beaker/puppet_install_helper'
 
-step 'Install Puppet'
-run_puppet_install_helper
+if ENV['SHA'].nil?
+  step 'Install Puppet'
+  run_puppet_install_helper
+else
+  step "Install puppet-agent..." do
+    opts = {
+      :puppet_collection    => 'PC1',
+      :puppet_agent_sha     => ENV['SHA'],
+      :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
+    }
+    install_puppet_agent_dev_repo_on(hosts, opts)
+  end
+
+  # make sure install is sane, beaker has already added puppet and ruby
+  # to PATH in ~/.ssh/environment
+  agents.each do |agent|
+    on agent, puppet('--version')
+  end
+end
 
 step 'Install Certs'
 install_ca_certs


### PR DESCRIPTION
Previously the beaker pupet installation helper is only able to use published
puppet agent version.  In order to satisfy PA-562 it should be possible to set
a custom puppet-agent version to be used during the acceptance tests.

This commit takes the puppet agent installation logic from the various
puppet-agent component pipelines and changes the behavior of the puppet-agent
installation based on the presence of the SHA environment variable.  This
variable is set during CI and local developer workflows when using a custom
puppet-agent build.