### PR TITLE
(MODULES-4918) Prepare module for 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,30 @@
-##2015-12-08 - Supported Release 1.1.2
+## 2017-05-19 - Supported Release 1.2.0
+
+### Summary
+
+Small release for support of newer PE versions and fix for a future Puppet Agent release.
+
+#### Features
+
+- Added compatibility for Windows 10.
+- Updated module with Puppet standard module development tools.
+
+#### Bug Fixes
+
+- Removed Windows 2003 as a supported Operating System.
+- Fixed minor issues in testing due to changes in Gem file dependencies.
+- Added support for localization.
+- Updated puppet version compatibility for modern Puppet agents ([MODULES-4838](https://tickets.puppetlabs.com/browse/MODULES-4838)).
+- Fixed issue ACL YAML serialization in Ruby 2.3.x ([MODULES-4275](https://tickets.puppetlabs.com/browse/MODULES-4275)).
+
+## 2015-12-08 - Supported Release 1.1.2
+
 ### Summary
 
 Small release for support of newer PE versions.
 
-##2015-07-28 - Supported Release 1.1.1
+## 2015-07-28 - Supported Release 1.1.1
+
 ### Summary
 
 Add Puppet 4 and PE 2015.2.0 to metadata
@@ -13,36 +34,43 @@ Add Puppet 4 and PE 2015.2.0 to metadata
 - Acceptance test fixes
 - Gemfile changes
 
-##2015-02-17 - Supported Release 1.1.0
+## 2015-02-17 - Supported Release 1.1.0
+
 ### Summary
 
 Deprecates `type` in permissions array has been renamed to `perm_type`
 
 #### Features
+
 - Permissions parameter now takes array of hashes with `perm_type` instead of Puppet 4.0 protected word `type`
 
-##2014-12-30 - Supported Release 1.0.4
+## 2014-12-30 - Supported Release 1.0.4
+
 ### Summary
 
 Bug fixes and typo in metadata summary
 
-##2014-08-25 - Supported Release 1.0.3
-###Summary
+## 2014-08-25 - Supported Release 1.0.3
+
+### Summary
 
 This release enables compatibility with x64-native ruby and puppet 3.7
 
-##2014-07-15 - Supported Release 1.0.2
-###Summary
+## 2014-07-15 - Supported Release 1.0.2
+
+### Summary
 
 This release merely updates metadata.json so the module can be uninstalled and
 upgraded via the puppet module command.
 
-##2014-03-04 - Supported Release 1.0.1
-###Summary
+## 2014-03-04 - Supported Release 1.0.1
+
+### Summary
 
 Add metadata compatibility for PE 3.2.
 
-##2014-03-04 - Supported Release 1.0.0
-###Summary
+## 2014-03-04 - Supported Release 1.0.0
+
+### Summary
 
 This is the initial supported release of the ACL module.

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "description": "This module provides the ability to manage ACLs on nodes. Currently the only operating system supported is Windows",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-acl",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": "Puppet Inc",
   "summary": "This module provides the ability to manage ACLs on nodes",
   "license": "Apache-2.0",
@@ -26,14 +26,13 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003",
-        "Server 2003 R2",
         "Server 2008",
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
         "7",
-        "8"
+        "8",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
Update puppet compatibility with 4.7 as lower bound  …
The Puppet Agent support is deprecated on many of the versions suggested in the
metadata.  This commit updates the lower bound of the dependency to puppet agent
4.7.0.

This commit preparse the module for a version 1.2.0 release.  Updated metadata
and changelog