### PR TITLE
(MODULES-4918) Prepare module for 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 2017-05-19 - Supported Release 1.2.0
+## 2017-05-19 - Supported Release 2.0.0
 
 ### Summary
 
-Small release for support of newer PE versions and fix for a future Puppet Agent release.
+Major release which removes support for older versions of Puppet-Agent.  Also adds support of newer PE versions and fix for a future Puppet Agent release.
 
 #### Features
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-acl",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "author": "Puppet Inc",
   "summary": "This module provides the ability to manage ACLs on nodes",
   "license": "Apache-2.0",


### PR DESCRIPTION
Previously the module would be release as 1.2.0 however as the module is
removing support for older Puppet Agent versions this is now a major version
change.