### PR TITLE
(MODULES-5152) Fix ACE mutation on output

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,12 @@
 ---
 Rakefile:
   unmanaged: true
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'rspec-puppet'
+        platforms: ["mswin", "mingw", "x64_mingw"]
+        version: '< 2.6.0'
 spec/spec_helper.rb:
   unmanaged: true
 appveyor.yml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_install:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.3.1
+  - rvm: 2.4.0
     bundler_args: --without system_tests
-    env: PUPPET_GEM_VERSION="~> 4.0"
-  - rvm: 2.1.7
+    env: PUPPET_GEM_VERSION="~> 5.0"
+  - rvm: 2.1.9
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 4.0"
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -43,13 +43,14 @@ minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 #end
 
 group :development do
-  gem "puppet-module-posix-default-r#{minor_version}", :require => false, :platforms => "ruby"
-  gem "puppet-module-win-default-r#{minor_version}",   :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "puppet-module-posix-dev-r#{minor_version}",     :require => false, :platforms => "ruby"
-  gem "puppet-module-win-dev-r#{minor_version}",       :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "json_pure", '<= 2.0.1',                         :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "fast_gettext", '1.1.0',                         :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "puppet-module-posix-default-r#{minor_version}",    :require => false, :platforms => "ruby"
+  gem "puppet-module-win-default-r#{minor_version}",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "puppet-module-posix-dev-r#{minor_version}",        :require => false, :platforms => "ruby"
+  gem "puppet-module-win-dev-r#{minor_version}", '0.0.7', :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "rspec-puppet", '< 2.6.0',                          :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
 end
 
 group :system_tests do
@@ -60,6 +61,7 @@ group :system_tests do
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ acl { 'c:/tempperms':
 }
 ~~~
 
-####Use multiple resources to manage the same target
+#### Use multiple resources to manage the same target
 
 You can manage the same target across multiple ACL resources, as long as each resource has a unique title.
 
@@ -293,7 +293,7 @@ acl { 'c:/tempperms':
 To remove permissions, set `purge => listed_permissions`. This removes explicit permissions from the ACL based on their `identity`, `perm_type`, `child_types` and `affects` attributes. The example below ensures that 'Administrator' and 'Authenticated Users' are not on the ACL.
 
 ~~~puppet
-#set permissions
+# set permissions
 acl { 'c:/tempperms/remove':
   purge                      => true,
   permissions                => [
@@ -306,7 +306,7 @@ acl { 'c:/tempperms/remove':
   inherit_parent_permissions => false,
 }
 
-#now remove some permissions
+# now remove some permissions
 acl { 'remove_tempperms/remove':
   target                     => 'c:/tempperms/remove',
   purge                      => 'listed_permissions',
@@ -437,7 +437,7 @@ To ensure that a specific set of permissions are absent from the ACL, set `purge
 
  * The 8.3 short filename format used in some versions of Windows is not supported.
 
- * We don't recommend using the acl module with Cywin, because it can yield inconsistent results --- especially when using Cygwin SSHD with public key authentication. For example, the 'Administrator' identity might work normally on Windows 2012, but on Windows 2008 it might be translated to 'cyg_server' (or vice-versa).
+ * We don't recommend using the acl module with Cygwin, because it can yield inconsistent results --- especially when using Cygwin SSHD with public key authentication. For example, the 'Administrator' identity might work normally on Windows 2012, but on Windows 2008 it might be translated to 'cyg_server' (or vice-versa).
 
  * Unicode encoding isn't supported in the `identity`, `group`, or `owner` parameters.
 
@@ -445,7 +445,7 @@ To ensure that a specific set of permissions are absent from the ACL, set `purge
 
 Please log tickets and issues at our [Module Issue Tracker](https://tickets.puppet.com/browse/MODULES).
 
-##Development
+## Development
 
 Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,11 @@ To ensure that a specific set of permissions are absent from the ACL, set `purge
 
  * When using SIDs for identities, autorequire tries to match to users with fully qualified names (e.g., User[BUILTIN\Administrators]) in addition to SIDs (User[S-1-5-32-544]). However, it can't match against 'User[Administrators]', because that could cause issues if domain accounts and local accounts share the same name e.g., 'Domain\Bob' and 'LOCAL\Bob'.
 
+ * When referring to accounts in the `APPLICATION PACKAGE AUTHORITY`, use either their SID values or their unqualified names. The Windows API has well documented bugs preventing the fully qualifed account names from being used.
+
+    * `S-1-15-2-1` or `ALL APPLICATION PACKAGES`, but *not* `APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES`. This account may only be referenced on Windows 2012R2 (kernel 6.3) or newer.
+    * `S-1-15-2-2` or `ALL RESTRICTED APPLICATION PACKAGES`, but *not* `APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES`. This account may only be referenced on Windows 2016 (kernel 10.0) or newer.
+
 Please log tickets and issues at our [Module Issue Tracker](https://tickets.puppet.com/browse/MODULES).
 
 ## Development

--- a/acceptance/tests/identity/specify_app_package_authority_idents.rb
+++ b/acceptance/tests/identity/specify_app_package_authority_idents.rb
@@ -1,0 +1,76 @@
+test_name 'Windows ACL Module - Specify APPLICATION PACKAGE AUTHORITY accounts'
+
+confine(:to, :platform => 'windows')
+
+[
+  { :id             => 'S-1-15-2-1',
+    :acl_regex      => /.*APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES:\(OI\)\(CI\)\(F\)/,
+    :minimum_kernel => 6.3,
+  },
+  # NOTE: 'APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES' doesn't work due to Windows API
+  { :id             => 'ALL APPLICATION PACKAGES',
+    :acl_regex      => /.*APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES:\(OI\)\(CI\)\(F\)/,
+    :minimum_kernel => 6.3,
+  },
+  { :id             => 'S-1-15-2-2',
+    :acl_regex      => /.*APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES:\(OI\)\(CI\)\(F\)/,
+    :minimum_kernel => 10.0,
+  },
+  # NOTE: 'APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES' doesn't work due to Windows API
+  { :id             => 'ALL RESTRICTED APPLICATION PACKAGES',
+    :acl_regex      => /.*APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES:\(OI\)\(CI\)\(F\)/,
+    :minimum_kernel => 10.0,
+  },
+].each do |account|
+
+  # randomize directory
+  target = "c:/#{SecureRandom.uuid}"
+  verify_acl_command = "icacls #{target}"
+
+  agents.each do |agent|
+    step "Check Minimum Supported OS for #{account[:id]}"
+    kernelmajversion = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    # try next agent if user is unsupported on this Windows version
+    if kernelmajversion < account[:minimum_kernel]
+      warn("This test requires Windows kernel #{account[:minimum_kernel]} but this host only has #{kernelmajversion}")
+      next
+    end
+
+    acl_manifest = <<-MANIFEST
+    file { '#{target}':
+      ensure => directory
+    }
+
+    acl { '#{target}':
+      permissions => [
+        { identity => '#{account[:id]}', rights => ['full'] },
+        { identity => 'Administrators', rights => ['full'] },
+      ],
+    }
+    MANIFEST
+
+    step "Execute ACL Manifest"
+    # exit code 2: The run succeeded, and some resources were changed.
+    on(agent, puppet('apply', '--detailed-exitcodes'), :stdin => acl_manifest, :acceptable_exit_codes => [2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    original_acl_rights = ''
+    step "Verify that ACL Rights are Correct"
+    on(agent, verify_acl_command) do |result|
+      original_acl_rights = result.stdout
+      assert_match(account[:acl_regex], original_acl_rights, 'Expected ACL was not present!')
+    end
+
+    step "Execute ACL Manifest again"
+    on(agent, puppet('apply'), :stdin => acl_manifest, :acceptable_exit_codes => [0]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step "Verify that ACL Rights are Correct again"
+    on(agent, verify_acl_command) do |result|
+      assert_match(account[:acl_regex], result.stdout, 'Expected ACL was not present!')
+      assert_equal(result.stdout, original_acl_rights)
+    end
+  end
+end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,16 +14,28 @@ environment:
     RUBY_VER: 21
   - PUPPET_GEM_VERSION: ~> 4.0
     RUBY_VER: 21-x64
-  - PUPPET_GEM_VERSION: ~> 4.0
-    RUBY_VER: 23
-  - PUPPET_GEM_VERSION: ~> 4.0
-    RUBY_VER: 23-x64
-  - PUPPET_GEM_VERSION: 4.2.3
+  - PUPPET_GEM_VERSION: ~> 5.0
+    RUBY_VER: 24
+  - PUPPET_GEM_VERSION: ~> 5.0
+    RUBY_VER: 24-x64
+  - PUPPET_GEM_VERSION: 4.7.1
     RUBY_VER: 21-x64
 matrix:
   fast_finish: true
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+- ps: |
+    # AppVeyor appears to have OpenSSL headers available already
+    # which msys2 would normally install with:
+    # pacman -S mingw-w64-x86_64-openssl --noconfirm
+    #
+    if ( $(ruby --version) -match "^ruby\s+2\.4" ) {
+      Write-Output "Building OpenSSL gem ~> 2.0.4 to fix Ruby 2.4 / AppVeyor issue"
+      gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc
+    }
+
+    gem list openssl
+    ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock
 build: off

--- a/lib/puppet/provider/acl/windows.rb
+++ b/lib/puppet/provider/acl/windows.rb
@@ -113,8 +113,10 @@ Puppet::Type.type(:acl).provide :windows do
     perms = permissions.select { |p| !p.is_inherited}
 
     unless perms.nil?
-      perms.each do |perm|
-        perm.identity = get_account_name(perm.identity)
+      perms = perms.map do |perm|
+        perm_hash = perm.to_hash
+        perm_hash['identity'] = get_account_name(perm.identity)
+        perm_hash
       end
     end
 

--- a/spec/unit/type/acl_spec.rb
+++ b/spec/unit/type/acl_spec.rb
@@ -507,12 +507,19 @@ describe Puppet::Type.type(:acl) do
     end
 
     context "formatting" do
-      it "when called from puppet resource should format like a hash and ASCIIbetical order properties when displaying" do
+      it "when called from puppet resource should format like a hash and ASCIIbetical order properties in Puppet 4 when displaying / adhere to desired ordering in Puppet 5" do
         # properties are out of order here
         resource[:permissions] = [{'rights'=>['full'], 'child_types' => 'containers', 'identity'=> 'bob'},{'rights'=>['full'], 'identity'=> 'tim'}]
 
         # ordered asciibetically
-        expected = "[{'child_types' => 'containers', 'identity' => 'bob', 'rights' => ['full']}, {'identity' => 'tim', 'rights' => ['full']}]"
+        is_puppet_5 = Gem::Version.new(Puppet::PUPPETVERSION.dup.freeze) >= Gem::Version.new('5.0.0')
+        if is_puppet_5
+          expected = "[
+  {'identity' => 'bob', 'rights' => ['full'], 'child_types' => 'containers'},
+  {'identity' => 'tim', 'rights' => ['full']}]"
+        else
+          expected = "[{'child_types' => 'containers', 'identity' => 'bob', 'rights' => ['full']}, {'identity' => 'tim', 'rights' => ['full']}]"
+        end
 
         Puppet::Parameter.format_value_for_display(resource[:permissions]).should == expected
       end


### PR DESCRIPTION
- Existing code mutates an Ace instance in the methods used to emit
   string versions of Ace objects - permissions_should_to_s and
   permissions_to_s. In particular, the `ALL APPLICATION PACKAGES`
   group is special as it must be specified without the leading
   `APPLICATION PACKAGE AUTHORITY` to properly resolve to a SID
   with the Windows API.

   Previously, for the sake of outputting the name of the group
   to users in the output of change messages / `puppet resource`,
   a SID name would be resolved to a complete name like
   `APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES` *and*
   the original Ace instance would be mutated causing future
   misbehavior as a result.

 - Previously permissions_to_s produced an Array of
   Puppet::Type::Acl::Ace objects, but now produces an Array of
   Ruby Hash objects, which can still be turned into log messages
   just fine. Puppet 5 in particular changed how values are
   logged to display to support arbitrarily nested structures.

 - Update documentation for how to use these accounts correctly.

 - Add integration tests for APPLICATION PACKAGES - though these
   unfortunately do not prove that the accounts can be used in a
   real manifest.