### PR TITLE
(maint) Remove skip_test on Unicode tests

### DIFF
--- a/acceptance/tests/group/group_local_unicode_group.rb
+++ b/acceptance/tests/group/group_local_unicode_group.rb
@@ -1,7 +1,5 @@
 test_name 'Windows ACL Module - Change Group to Local Unicode Group'
 
-skip_test("This test requires QENG-449 to be resolved")
-
 confine(:to, :platform => 'windows')
 
 #Globals

--- a/acceptance/tests/group/group_local_unicode_user.rb
+++ b/acceptance/tests/group/group_local_unicode_user.rb
@@ -1,7 +1,5 @@
 test_name 'Windows ACL Module - Change Group to Local Unicode User'
 
-skip_test("This test requires QENG-449 to be resolved")
-
 confine(:to, :platform => 'windows')
 
 #Globals

--- a/acceptance/tests/identity/specify_unicode_group_ident.rb
+++ b/acceptance/tests/identity/specify_unicode_group_ident.rb
@@ -1,7 +1,5 @@
 test_name 'Windows ACL Module - Specify Group Name Containing Unicode for Identity'
 
-skip_test("This test requires QENG-449 to be resolved")
-
 confine(:to, :platform => 'windows')
 
 #Globals

--- a/acceptance/tests/identity/specify_unicode_user_ident.rb
+++ b/acceptance/tests/identity/specify_unicode_user_ident.rb
@@ -1,7 +1,5 @@
 test_name 'Windows ACL Module - Specify User Name Containing Unicode for Identity'
 
-skip_test("This test requires QENG-449 to be resolved")
-
 confine(:to, :platform => 'windows')
 
 #Globals

--- a/acceptance/tests/owner/owner_local_unicode_group.rb
+++ b/acceptance/tests/owner/owner_local_unicode_group.rb
@@ -1,7 +1,5 @@
 test_name 'Windows ACL Module - Change Owner to Local Unicode Group'
 
-skip_test("This test requires QENG-449 to be resolved")
-
 confine(:to, :platform => 'windows')
 
 #Globals
@@ -20,7 +18,8 @@ verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
 file_content_regex = /\A#{file_content}\z/
 
 dosify_target = "c:\\#{parent_name}\\#{target_name}"
-verify_owner_command = "cmd /c \"dir /q #{dosify_target}\""
+verify_owner_command = "powershell.exe -command \"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
+
 owner_regex = /.*\\䎈含㴼罍率䎁叴秀㪲軞/
 
 #Manifests

--- a/acceptance/tests/owner/owner_local_unicode_user.rb
+++ b/acceptance/tests/owner/owner_local_unicode_user.rb
@@ -1,7 +1,5 @@
 test_name 'Windows ACL Module - Change Owner to Local Unicode User'
 
-skip_test("This test requires QENG-449 to be resolved")
-
 confine(:to, :platform => 'windows')
 
 #Globals
@@ -20,7 +18,7 @@ verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
 file_content_regex = /\A#{file_content}\z/
 
 dosify_target = "c:\\#{parent_name}\\#{target_name}"
-verify_owner_command = "cmd /c \"dir /q #{dosify_target}\""
+verify_owner_command = "powershell.exe -command \"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
 owner_regex = /.*\\ΣΤΥΦ/
 
 #Manifests


### PR DESCRIPTION
 - Some test could simply have their skip_test removed
 - For some tests dir /q didn't return owner in the format we'd like
   and instead moved to PowerShell Get-Acl command which has better
   filtering / formatting capabilities
 - For the unicode_dir and unicode_file tests, their checks had to
   be rewritten in a more saavy way. While it wasn't possible to pass
   Unicode strings through the shell when performing a `cat` or `dir`
   it was possible to have PowerShell perform queries and return the
   name of the directory or file through SSH properly.

   In these cases, assertions could be slightly rewritten to instead
   match on a filename that matched criteria, rather than matching on
   the output of a command like icacls.