### PR TITLE
(maint) PS2 compat for Unicode acceptance tests

### DIFF
--- a/acceptance/tests/owner/owner_local_unicode_group.rb
+++ b/acceptance/tests/owner/owner_local_unicode_group.rb
@@ -18,7 +18,7 @@ verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
 file_content_regex = /\A#{file_content}\z/
 
 dosify_target = "c:\\#{parent_name}\\#{target_name}"
-verify_owner_command = "powershell.exe -command \"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
+verify_owner_command = "\"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
 
 owner_regex = /.*\\䎈含㴼罍率䎁叴秀㪲軞/
 
@@ -63,7 +63,7 @@ agents.each do |agent|
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, verify_owner_command) do |result|
+  on(agent, powershell(verify_owner_command)) do |result|
     assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
   end
 

--- a/acceptance/tests/owner/owner_local_unicode_user.rb
+++ b/acceptance/tests/owner/owner_local_unicode_user.rb
@@ -18,7 +18,7 @@ verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
 file_content_regex = /\A#{file_content}\z/
 
 dosify_target = "c:\\#{parent_name}\\#{target_name}"
-verify_owner_command = "powershell.exe -command \"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
+verify_owner_command = "\"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
 owner_regex = /.*\\ΣΤΥΦ/
 
 #Manifests
@@ -65,7 +65,7 @@ agents.each do |agent|
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, verify_owner_command) do |result|
+  on(agent, powershell(verify_owner_command)) do |result|
     assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
   end
 

--- a/acceptance/tests/parameter_target/add_perms_to_unicode_dir.rb
+++ b/acceptance/tests/parameter_target/add_perms_to_unicode_dir.rb
@@ -9,7 +9,7 @@ target = "c:/temp/#{dirname}"
 user_id = 'bob'
 
 # ensure bob has Full rights with object and container inherit set
-verify_acl_command = "powershell.exe -command \"Get-Acl C:\\temp\\unicode_dir_* | ? { \\$_.Access | ? { \\$_.IdentityReference -match '\\\\\\bob' -and \\$_.FileSystemRights -eq 'FullControl' -and \\$_.InheritanceFlags -eq 'ContainerInherit, ObjectInherit' } } | Select -ExpandProperty PSChildName\""
+verify_acl_command = "\"Get-Acl C:\\temp\\unicode_dir_* | ? { \\$_.Access | ? { \\$_.IdentityReference -match '\\\\\\bob' -and \\$_.FileSystemRights -eq 'FullControl' -and \\$_.InheritanceFlags -eq 'ContainerInherit, ObjectInherit' } } | Select -ExpandProperty PSChildName\""
 
 #Manifest
 acl_manifest = <<-MANIFEST
@@ -44,7 +44,7 @@ agents.each do |agent|
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, verify_acl_command) do |result|
+  on(agent, powershell(verify_acl_command)) do |result|
     assert_match(/^#{dirname}$/, result.stdout, 'Expected ACL was not present!')
   end
 end

--- a/acceptance/tests/parameter_target/add_perms_to_unicode_file.rb
+++ b/acceptance/tests/parameter_target/add_perms_to_unicode_file.rb
@@ -9,11 +9,11 @@ target = "c:/temp/#{filename}"
 user_id = 'bob'
 
 file_content = 'Puppets and Muppets! Cats on the Interwebs!'
-verify_content_command = 'powershell.exe -command "Get-ChildItem c:\\temp\\* -File | % { \\$_.PSChildName, (Get-Content \\$_) }"'
+verify_content_command = '"Get-ChildItem c:\\temp\\* | ? { ! \\$_.PSIsContainer } | % { \\$_.PSChildName, (Get-Content \\$_) }"'
 file_content_regex = /^#{filename}\n#{file_content}$/m
 
 # ensure bob has Full rights
-verify_acl_command = "powershell.exe -command \"Get-Acl C:\\temp\\*.* | ? { \\$_.Access | ? { \\$_.IdentityReference -match '\\\\\\#{user_id}' -and \\$_.FileSystemRights -eq 'FullControl' } } | Select -ExpandProperty PSChildName\""
+verify_acl_command = "\"Get-Acl C:\\temp\\*.* | ? { \\$_.Access | ? { \\$_.IdentityReference -match '\\\\\\#{user_id}' -and \\$_.FileSystemRights -eq 'FullControl' } } | Select -ExpandProperty PSChildName\""
 
 #Manifest
 acl_manifest = <<-MANIFEST
@@ -44,17 +44,17 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute Manifest"
-  on(agent, puppet('apply', '--debug'), :stdin => acl_manifest) do |result|
+  on(agent, puppet('apply', '--debug', '--trace', '--verbose'), :stdin => acl_manifest) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, verify_acl_command) do |result|
+  on(agent, powershell(verify_acl_command)) do |result|
     assert_match(/^#{filename}$/, result.stdout, 'Expected ACL was not present!')
   end
 
   step "Verify File Data Integrity"
-  on(agent, verify_content_command) do |result|
+  on(agent, powershell(verify_content_command)) do |result|
     assert_match(file_content_regex, result.stdout, 'Expected file content is invalid!')
   end
 end


### PR DESCRIPTION
 - Switch to the Beaker `powershell` helper which behaves properly
   when run under PS2 (by using -NonInteractive command line switch
   which prevents stdin issues under Cygwin).

 - Replace Get-ChildItem -File with the PS2 correct code since the
   -File switch was only added in PS3:

   Get-ChildItem | ? { ! $_.PsContainer}