### PR TITLE
(maint) Update tests to properly interpret Unicode

### DIFF
--- a/acceptance/tests/group/group_local_unicode_group.rb
+++ b/acceptance/tests/group/group_local_unicode_group.rb
@@ -3,22 +3,20 @@ test_name 'Windows ACL Module - Change Group to Local Unicode Group'
 confine(:to, :platform => 'windows')
 
 #Globals
-user_type = 'local_unicode_group'
+prefix = SecureRandom.uuid.to_s
 file_content = 'Dangers driving drunk while insane.'
 
 parent_name = 'temp'
-target_name = "group_#{user_type}.txt"
+target_name = "#{prefix}.txt"
 
 target_parent = "c:/#{parent_name}"
 target = "#{target_parent}/#{target_name}"
 user_id = 'bob'
-group_id = '䎈含㴼罍率䎁叴秀㪲軞'
 
-verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
-file_content_regex = /\A#{file_content}\z/
+raw_group_id = 'group_\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE'
+group_id =     "group_\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE" # 䎈含㴼罍率䎁叴秀㪲軞
 
-verify_group_command = "icacls #{target}"
-group_regex = /.*\\䎈含㴼罍率䎁叴秀㪲軞:\(M\)/
+verify_group_command = "(Get-ACL '#{target}' | Where-Object { $_.Group -match ('.*\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) } | Measure-Object).Count"
 
 #Manifests
 acl_manifest = <<-MANIFEST
@@ -66,17 +64,12 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute ACL Manifest"
-  on(agent, puppet('apply', '--debug'), :stdin => acl_manifest) do |result|
+  apply_manifest_on(agent, acl_manifest, {:debug => true}) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, verify_group_command) do |result|
-    assert_match(group_regex, result.stdout, 'Expected ACL was not present!')
-  end
-
-  step "Verify File Data Integrity"
-  on(agent, verify_content_command) do |result|
-    assert_match(file_content_regex, result.stdout, 'File content is invalid!')
+  on(agent, powershell(verify_group_command, {'EncodedCommand' => true})) do |result|
+    assert_match(/^1$/, result.stdout, 'Expected ACL was not present!')
   end
 end

--- a/acceptance/tests/identity/specify_unicode_user_ident.rb
+++ b/acceptance/tests/identity/specify_unicode_user_ident.rb
@@ -4,15 +4,13 @@ confine(:to, :platform => 'windows')
 
 #Globals
 target_parent = 'c:/temp'
-target = 'c:/temp/specify_unicode_user_ident.txt'
-user_id = "user_렝딴슫있처"
+prefix = SecureRandom.uuid.to_s
+target = "c:/temp/#{prefix}.txt"
+raw_user_id = 'user_\uB81D\uB534\uC2AB\uC788\uCC98'
+user_id =     "user_\uB81D\uB534\uC2AB\uC788\uCC98" # 렝딴슫있처
 
 file_content = 'Flying Spaghetti Monster wants to save your soul.'
-verify_content_command = "cat /cygdrive/c/temp/specify_unicode_user_ident.txt"
-file_content_regex = /\A#{file_content}\z/
-
-verify_acl_command = "icacls #{target}"
-acl_regex = /.*\\user_렝딴슫있처:\(F\)/
+verify_acl_command = "(Get-ACL '#{target}' | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match ('\\\\' + [regex]::Unescape(\"#{raw_user_id}\")) -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count"
 
 #Manifest
 acl_manifest = <<-MANIFEST
@@ -43,17 +41,12 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute Manifest"
-  on(agent, puppet('apply', '--debug'), :stdin => acl_manifest) do |result|
+  apply_manifest_on(agent, acl_manifest, {:debug => true}) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, verify_acl_command) do |result|
-    assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
-  end
-
-  step "Verify File Data Integrity"
-  on(agent, verify_content_command) do |result|
-    assert_match(file_content_regex, result.stdout, 'Expected file content is invalid!')
+  on(agent, powershell(verify_acl_command, {'EncodedCommand' => true})) do |result|
+    assert_match(/^1$/, result.stdout, 'Expected ACL was not present!')
   end
 end

--- a/acceptance/tests/owner/owner_local_unicode_group.rb
+++ b/acceptance/tests/owner/owner_local_unicode_group.rb
@@ -3,24 +3,20 @@ test_name 'Windows ACL Module - Change Owner to Local Unicode Group'
 confine(:to, :platform => 'windows')
 
 #Globals
-user_type = 'local_unicode_group'
 file_content = 'I thought things on a Saturday night.'
 
 parent_name = 'temp'
-target_name = "owner_#{user_type}.txt"
+prefix = SecureRandom.uuid.to_s
+target_name = "#{prefix}.txt"
 
 target_parent = "c:/#{parent_name}"
 target = "#{target_parent}/#{target_name}"
 user_id = 'bob'
-owner_id = '䎈含㴼罍率䎁叴秀㪲軞'
 
-verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
-file_content_regex = /\A#{file_content}\z/
+raw_owner_id = '\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE'
+owner_id =     "\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE" # 䎈含㴼罍率䎁叴秀㪲軞
 
-dosify_target = "c:\\#{parent_name}\\#{target_name}"
-verify_owner_command = "\"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
-
-owner_regex = /.*\\䎈含㴼罍率䎁叴秀㪲軞/
+verify_owner_command = "(Get-ACL '#{target}' | Where-Object { $_.Owner -match ('.*\\\\' + [regex]::Unescape(\"#{raw_owner_id}\")) } | Measure-Object).Count"
 
 #Manifests
 acl_manifest = <<-MANIFEST
@@ -58,17 +54,12 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute ACL Manifest"
-  on(agent, puppet('apply', '--debug'), :stdin => acl_manifest) do |result|
+  apply_manifest_on(agent, acl_manifest, {:debug => true}) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, powershell(verify_owner_command)) do |result|
-    assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
-  end
-
-  step "Verify File Data Integrity"
-  on(agent, verify_content_command) do |result|
-    assert_match(file_content_regex, result.stdout, 'File content is invalid!')
+  on(agent, powershell(verify_owner_command, {'EncodedCommand' => true})) do |result|
+    assert_match(/^1$/, result.stdout, 'Expected ACL was not present!')
   end
 end

--- a/acceptance/tests/owner/owner_local_unicode_user.rb
+++ b/acceptance/tests/owner/owner_local_unicode_user.rb
@@ -7,19 +7,18 @@ user_type = 'local_unicode_user'
 file_content = 'Blurpy Bing Dangle.'
 
 parent_name = 'temp'
-target_name = "owner_#{user_type}.txt"
+prefix = SecureRandom.uuid.to_s
+target_name = "#{prefix}.txt"
 
 target_parent = "c:/#{parent_name}"
 target = "#{target_parent}/#{target_name}"
 user_id = 'bob'
-owner_id = 'ΣΤΥΦ'
 
-verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
-file_content_regex = /\A#{file_content}\z/
+raw_owner_id = '\u03A3\u03A4\u03A5\u03A6'
+owner_id =     "\u03A3\u03A4\u03A5\u03A6" # ΣΤΥΦ
 
 dosify_target = "c:\\#{parent_name}\\#{target_name}"
-verify_owner_command = "\"Get-Acl #{dosify_target} | Select -ExpandProperty Owner\""
-owner_regex = /.*\\ΣΤΥΦ/
+verify_owner_command = "(Get-ACL '#{target}' | Where-Object { $_.Owner -match ('.*\\\\' + [regex]::Unescape(\"#{raw_owner_id}\")) } | Measure-Object).Count"
 
 #Manifests
 acl_manifest = <<-MANIFEST
@@ -60,17 +59,12 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute ACL Manifest"
-  on(agent, puppet('apply', '--debug'), :stdin => acl_manifest) do |result|
+  apply_manifest_on(agent, acl_manifest, {:debug => true}) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, powershell(verify_owner_command)) do |result|
-    assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
-  end
-
-  step "Verify File Data Integrity"
-  on(agent, verify_content_command) do |result|
-    assert_match(file_content_regex, result.stdout, 'File content is invalid!')
+  on(agent, powershell(verify_owner_command, {'EncodedCommand' => true})) do |result|
+    assert_match(/^1$/, result.stdout, 'Expected ACL was not present!')
   end
 end

--- a/acceptance/tests/parameter_target/add_perms_to_unicode_dir.rb
+++ b/acceptance/tests/parameter_target/add_perms_to_unicode_dir.rb
@@ -4,12 +4,14 @@ confine(:to, :platform => 'windows')
 
 #Globals
 target_parent = 'c:/temp'
-dirname = "unicode_dir_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158"
-target = "c:/temp/#{dirname}"
+prefix = SecureRandom.uuid.to_s
+raw_dirname = prefix + '_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158'
+dirname =     "#{prefix}_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158"
+target = "#{target_parent}/#{dirname}"
 user_id = 'bob'
 
 # ensure bob has Full rights with object and container inherit set
-verify_acl_command = "\"Get-Acl C:\\temp\\unicode_dir_* | ? { \\$_.Access | ? { \\$_.IdentityReference -match '\\\\\\bob' -and \\$_.FileSystemRights -eq 'FullControl' -and \\$_.InheritanceFlags -eq 'ContainerInherit, ObjectInherit' } } | Select -ExpandProperty PSChildName\""
+verify_acl_command = "(Get-ACL ('#{target_parent}/' + [regex]::Unescape(\"#{raw_dirname}\")) | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match '\\\\bob' -and $_.FileSystemRights -eq 'FullControl' -and $_.InheritanceFlags -eq 'ContainerInherit, ObjectInherit' } | Measure-Object).Count"
 
 #Manifest
 acl_manifest = <<-MANIFEST
@@ -39,12 +41,13 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute Manifest"
-  on(agent, puppet('apply', '--debug'), :stdin => acl_manifest) do |result|
+
+  apply_manifest_on(agent, acl_manifest, {:debug => true}) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, powershell(verify_acl_command)) do |result|
-    assert_match(/^#{dirname}$/, result.stdout, 'Expected ACL was not present!')
+  on(agent, powershell(verify_acl_command, {'EncodedCommand' => true})) do |result|
+    assert_match(/^1$/, result.stdout, 'Expected ACL was not present!')
   end
 end

--- a/acceptance/tests/parameter_target/add_perms_to_unicode_file.rb
+++ b/acceptance/tests/parameter_target/add_perms_to_unicode_file.rb
@@ -4,16 +4,16 @@ confine(:to, :platform => 'windows')
 
 #Globals
 target_parent = 'c:/temp'
-filename = "unicode_file_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt"
-target = "c:/temp/#{filename}"
+prefix = SecureRandom.uuid.to_s
+raw_filename = prefix + '_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt'
+filename     = "#{prefix}_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt"
+target = "#{target_parent}/#{filename}"
 user_id = 'bob'
 
 file_content = 'Puppets and Muppets! Cats on the Interwebs!'
-verify_content_command = '"Get-ChildItem c:\\temp\\* | ? { ! \\$_.PSIsContainer } | % { \\$_.PSChildName, (Get-Content \\$_) }"'
-file_content_regex = /^#{filename}\n#{file_content}$/m
 
 # ensure bob has Full rights
-verify_acl_command = "\"Get-Acl C:\\temp\\*.* | ? { \\$_.Access | ? { \\$_.IdentityReference -match '\\\\\\#{user_id}' -and \\$_.FileSystemRights -eq 'FullControl' } } | Select -ExpandProperty PSChildName\""
+verify_acl_command = "(Get-Acl ('#{target_parent}/' + [regex]::Unescape(\"#{raw_filename}\")) | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match '\\\\#{user_id}' -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count"
 
 #Manifest
 acl_manifest = <<-MANIFEST
@@ -44,17 +44,12 @@ MANIFEST
 #Tests
 agents.each do |agent|
   step "Execute Manifest"
-  on(agent, puppet('apply', '--debug', '--trace', '--verbose'), :stdin => acl_manifest) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+  apply_manifest_on(agent, acl_manifest, {:debug => true}) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify that ACL Rights are Correct"
-  on(agent, powershell(verify_acl_command)) do |result|
-    assert_match(/^#{filename}$/, result.stdout, 'Expected ACL was not present!')
-  end
-
-  step "Verify File Data Integrity"
-  on(agent, powershell(verify_content_command)) do |result|
-    assert_match(file_content_regex, result.stdout, 'Expected file content is invalid!')
+  on(agent, powershell(verify_acl_command, {'EncodedCommand' => true})) do |result|
+    assert_match(/^1$/, result.stdout, 'Expected ACL was not present!')
   end
 end


### PR DESCRIPTION
Previously, the acceptance tests were accidentally working due to a combination
of ruby, cygwin and beaker all correctly corrupting Unicode characters when
transmitted over STDIN/STDOUT.  This commit changes the communication transports
used to ones that retain the unicode information and are succesfully applied on
the system under test.  This commit also removes the file content tests as they
are better served by using unique test fixture names instead of relying on the
file content to be valid.