### PR TITLE
(maint) Modify beaker rake task to invoke beaker directly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,19 @@ end
 
 task :default => [:test]
 
+# The acceptance tests for ACL are written in standard beaker format however
+# the preferred method is using beaker-rspec.  This rake task overrides the 
+# default `beaker` task, which would normally use beaker-rspec, and instead
+# invokes beaker directly.  This is only need while the module tests are migrated
+# to the newer rspec-beaker format
+task_exists = Rake.application.tasks.any? { |t| t.name == 'beaker' }
+Rake::Task['beaker'].clear if task_exists
+desc 'Run acceptance testing shim'
+task :beaker do |t, args|
+  beaker_cmd = "beaker --options-file acceptance/.beaker-pe.cfg --hosts #{ENV['BEAKER_setfile']} --tests acceptance/tests --keyfile #{ENV['BEAKER_keyfile']}"
+  Kernel.system( beaker_cmd )
+end
+
 desc 'Run RSpec'
 RSpec::Core::RakeTask.new(:test) do |t|
   t.pattern = 'spec/{unit}/**/*.rb'


### PR DESCRIPTION
The acceptance tests for ACL are written in standard beaker format however
the preferred method is using beaker-rspec.  This commit overrides the
default `beaker` task, which would normally use beaker-rspec, and instead
invokes beaker directly.  This is only need while the module tests are migrated
to the newer rspec-beaker format.