### PR TITLE
(MODULES-6739) Add Testmode switcher

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,10 @@ Gemfile:
       - gem: 'rspec-puppet'
         platforms: ["mswin", "mingw", "x64_mingw"]
         version: '< 2.6.0'
+    ':system_tests':
+      - gem: beaker-testmode_switcher
+        version: '~> 0.4'
+      - gem: master_manipulator
 spec/spec_helper.rb:
   unmanaged: true
 appveyor.yml:

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ group :system_tests do
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-testmode_switcher", '~> 0.4',                                      :require => false
+  gem 'master_manipulator',                                                      :require => false
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 

--- a/spec/acceptance/access_rights_directory/allow_rights_dir_spec.rb
+++ b/spec/acceptance/access_rights_directory/allow_rights_dir_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_with_rights(acl_regex, agent, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, rights)) do |result|
+      execute_manifest_on(agent, acl_manifest(target, rights), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_directory/deny_rights_dir_spec.rb
+++ b/spec/acceptance/access_rights_directory/deny_rights_dir_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_with_rights(acl_regex, agent, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, rights)) do |result|
+      execute_manifest_on(agent, acl_manifest(target, rights), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_directory/mask_specific/allow_rights_dir_mask_spec.rb
+++ b/spec/acceptance/access_rights_directory/mask_specific/allow_rights_dir_mask_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def execute_manifest_with_mask(acl_regex, agent, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(mask)) do |result|
+      execute_manifest_on(agent, acl_manifest(mask), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_directory/mask_specific/deny_rights_dir_mask_spec.rb
+++ b/spec/acceptance/access_rights_directory/mask_specific/deny_rights_dir_mask_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def execute_manifest_with_mask(acl_regex, agent, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(mask)) do |result|
+      execute_manifest_on(agent, acl_manifest(mask), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_file/allow_rights_file_spec.rb
+++ b/spec/acceptance/access_rights_file/allow_rights_file_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, rights, file_content)) do |result|
+      execute_manifest_on(agent, acl_manifest(target, rights, file_content), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_file/deny_rights_file_spec.rb
+++ b/spec/acceptance/access_rights_file/deny_rights_file_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, rights, file_content)) do |result|
+      execute_manifest_on(agent, acl_manifest(target, rights, file_content), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_file/mask_specific/allow_rights_file_mask_spec.rb
+++ b/spec/acceptance/access_rights_file/mask_specific/allow_rights_file_mask_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(acl_regex, agent, file_content, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(mask, file_content)) do |result|
+      execute_manifest_on(agent, acl_manifest(mask, file_content), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/access_rights_file/mask_specific/deny_rights_file_mask_spec.rb
+++ b/spec/acceptance/access_rights_file/mask_specific/deny_rights_file_mask_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(acl_regex, agent, file_content, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(mask, file_content)) do |result|
+      execute_manifest_on(agent, acl_manifest(mask, file_content), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/basic_functionality/negative/negative_acl_on_linux_spec.rb
+++ b/spec/acceptance/basic_functionality/negative/negative_acl_on_linux_spec.rb
@@ -16,7 +16,7 @@ describe 'Basic Functionality - Negative' do
   context 'ACL Fails Gracefully on Linux' do
     linux_agents.each do |agent|
       it "Verify that the 'acl' Type Does not Work on Non-Windows Agents on #{agent}" do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest) do |result|
+        execute_manifest_on(agent, acl_manifest, { :debug => true }) do |result|
           assert_match(%r{Error: Could not find a suitable provider for acl}, result.stderr, 'Expected error was not detected!')
         end
       end

--- a/spec/acceptance/group/group_local_spec.rb
+++ b/spec/acceptance/group/group_local_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(agent, file_content, group_id, group_regex, user_type)
   context "on #{agent}" do
     it 'Execute ACL Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(user_type, file_content, group_id)) do |result|
+      execute_manifest_on(agent, acl_manifest(user_type, file_content, group_id), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/group/group_local_unicode_group_spec.rb
+++ b/spec/acceptance/group/group_local_unicode_group_spec.rb
@@ -62,7 +62,7 @@ describe 'Group - Unicode' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          apply_manifest_on(agent, acl_manifest(prefix, file_content, group_id), debug: true) do |result|
+          execute_manifest_on(agent, acl_manifest(prefix, file_content, group_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/group/group_local_unicode_user_spec.rb
+++ b/spec/acceptance/group/group_local_unicode_user_spec.rb
@@ -61,7 +61,7 @@ describe 'Group - Unicode' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          apply_manifest_on(agent, acl_manifest(prefix, file_content, group_id), debug: true) do |result|
+          execute_manifest_on(agent, acl_manifest(prefix, file_content, group_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/group/group_local_user_sid_spec.rb
+++ b/spec/acceptance/group/group_local_user_sid_spec.rb
@@ -91,7 +91,7 @@ describe 'Group - SID' do
         end
 
         it 'Execute Setup Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: setup_manifest(target_parent, target, file_content, user_id, group_id)) do |result|
+          execute_manifest_on(agent, setup_manifest(target_parent, target, file_content, user_id, group_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -103,7 +103,7 @@ describe 'Group - SID' do
         end
 
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, user_id, sid)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, user_id, sid), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/group/negative/group_257_char_name_spec.rb
+++ b/spec/acceptance/group/negative/group_257_char_name_spec.rb
@@ -56,7 +56,7 @@ describe 'Group - Negative' do
   windows_agents.each do |agent|
     context "On Windows Agent Change Group to Local Group with Long Name on #{agent}" do
       it 'Attempt to Execute ACL Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest) do |result|
+        execute_manifest_on(agent, acl_manifest, { :debug => true }) do |result|
           assert_match(expected_error, result.stderr, 'Expected error was not detected!')
         end
 

--- a/spec/acceptance/identity/negative/specify_identity_spec.rb
+++ b/spec/acceptance/identity/negative/specify_identity_spec.rb
@@ -33,7 +33,7 @@ describe 'Identity - Negative' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_file, file_content, group_id)) do |result|
+          execute_manifest_on(agent, acl_manifest(target_file, file_content, group_id), { :debug => true }) do |result|
             assert_match(%r{Error: Failed to set permissions for }, result.stderr, 'Expected error was not detected!')
           end
         end
@@ -55,7 +55,7 @@ describe 'Identity - Negative' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_file, file_content, user_id)) do |result|
+          execute_manifest_on(agent, acl_manifest(target_file, file_content, user_id), { :debug => true }) do |result|
             assert_match(%r{Error: Failed to set permissions for 'user_not_here'}, result.stderr, 'Expected error was not detected!')
           end
         end

--- a/spec/acceptance/identity/specify_app_package_authority_idents_spec.rb
+++ b/spec/acceptance/identity/specify_app_package_authority_idents_spec.rb
@@ -45,7 +45,7 @@ describe 'Identity' do
 
             it 'Execute ACL Manifest' do
               # exit code 2: The run succeeded, and some resources were changed.
-              on(agent, puppet('apply', '--detailed-exitcodes'), stdin: acl_manifest, acceptable_exit_codes: [2]) do |result|
+              execute_manifest_on(agent, acl_manifest, { :expect_changes => true }) do |result|
                 assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
               end
             end
@@ -59,7 +59,7 @@ describe 'Identity' do
             end
 
             it 'Execute ACL Manifest again' do
-              on(agent, puppet('apply'), stdin: acl_manifest, acceptable_exit_codes: [0]) do |result|
+              execute_manifest_on(agent, acl_manifest, { :catch_changes => true } ) do |result|
                 assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
               end
             end

--- a/spec/acceptance/identity/specify_group_identity_spec.rb
+++ b/spec/acceptance/identity/specify_group_identity_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(agent, file_content, group_id, target_file)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest_with_group(target_file, file_content, group_id)) do |result|
+      execute_manifest_on(agent, acl_manifest_with_group(target_file, file_content, group_id), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/identity/specify_sid_identity_spec.rb
+++ b/spec/acceptance/identity/specify_sid_identity_spec.rb
@@ -59,7 +59,7 @@ describe 'Module - Identity' do
         end
 
         it 'Execute Setup Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: setup_manifest(target_file, file_content)) do |result|
+          execute_manifest_on(agent, setup_manifest(target_file, file_content), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -71,7 +71,7 @@ describe 'Module - Identity' do
         end
 
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_file, sid)) do |result|
+          execute_manifest_on(agent, acl_manifest(target_file, sid), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/identity/specify_unicode_identity_spec.rb
+++ b/spec/acceptance/identity/specify_unicode_identity_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper_acceptance'
 # rubocop:disable RSpec/EmptyExampleGroup
 def apply_manifest_and_verify(agent, file_content, target, user_id, verify_acl_command)
   it 'Execute Manifest' do
-    apply_manifest_on(agent, acl_manifest_user(target, file_content, user_id), debug: true) do |result|
+    execute_manifest_on(agent, acl_manifest_user(target, file_content, user_id), { :debug => true }) do |result|
       assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
     end
   end
@@ -78,7 +78,7 @@ describe 'Identity' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Manifest' do
-          apply_manifest_on(agent, acl_manifest_group(target, file_content, group_id), debug: true) do |result|
+          execute_manifest_on(agent, acl_manifest_group(target, file_content, group_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/identity/specify_user_identity_spec.rb
+++ b/spec/acceptance/identity/specify_user_identity_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(agent, file_content, user_id, target_file)
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(file_content, user_id, target_file)) do |result|
+      execute_manifest_on(agent, acl_manifest(file_content, user_id, target_file), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/inheritance/inheritance_on_dir_spec.rb
+++ b/spec/acceptance/inheritance/inheritance_on_dir_spec.rb
@@ -10,7 +10,7 @@ def apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_chi
 
   context "on #{agent}" do
     it 'Execute Apply Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, target_child, user_id_child, rights, perm_type, child_inherit_type)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, target_child, user_id_child, rights, perm_type, child_inherit_type), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/inheritance/inheritance_on_file_spec.rb
+++ b/spec/acceptance/inheritance/inheritance_on_file_spec.rb
@@ -10,7 +10,7 @@ def apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_chi
 
   context "on #{agent}" do
     it 'Execute Apply Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, target_child, file_content, user_id_child, rights, perm_type, child_inherit_type)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, target_child, file_content, user_id_child, rights, perm_type, child_inherit_type), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/owner/negative/owner_257_char_name_spec.rb
+++ b/spec/acceptance/owner/negative/owner_257_char_name_spec.rb
@@ -7,7 +7,7 @@ def apply_manifest_and_verify(agent, target_name, file_content, user_id, owner_i
     verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
 
     it 'Attempt to Execute ACL Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, file_content, user_id, owner_id)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, file_content, user_id, owner_id), { :debug => true }) do |result|
         assert_match(expected_error, result.stderr, 'Expected error was not detected!')
       end
     end

--- a/spec/acceptance/owner/owner_local_group_spec.rb
+++ b/spec/acceptance/owner/owner_local_group_spec.rb
@@ -8,7 +8,7 @@ def apply_manifest_and_verify(agent, target_name, file_content, owner_id, owner_
     verify_owner_command = "cmd /c \"dir /q #{dosify_target}\""
 
     it 'Execute ACL Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, file_content, owner_id)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -95,7 +95,7 @@ describe 'Owner - Local Group' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          apply_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
+          execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/owner/owner_local_user_sid_spec.rb
+++ b/spec/acceptance/owner/owner_local_user_sid_spec.rb
@@ -74,7 +74,7 @@ describe 'Owner - SID' do
         end
 
         it 'Execute Setup Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: setup_manifest(target_name, file_content, owner_id)) do |result|
+          execute_manifest_on(agent, setup_manifest(target_name, file_content, owner_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -86,7 +86,7 @@ describe 'Owner - SID' do
         end
 
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, sid)) do |result|
+          execute_manifest_on(agent, acl_manifest(target_name, sid), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/owner/owner_local_user_spec.rb
+++ b/spec/acceptance/owner/owner_local_user_spec.rb
@@ -8,7 +8,7 @@ def apply_manifest_and_verify(agent, file_content, owner_id, target_name, owner_
     verify_owner_command = "cmd /c \"dir /q #{dosify_target}\""
 
     it 'Execute ACL Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, file_content, owner_id)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -99,7 +99,7 @@ describe 'Owner - Local User' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          apply_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
+          execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/parameter_target/explicit_target_spec.rb
+++ b/spec/acceptance/parameter_target/explicit_target_spec.rb
@@ -33,7 +33,7 @@ describe 'Windows ACL Module - Explicit Use of "target" Parameter' do
   windows_agents.each do |agent|
     context "on #{agent}" do
       it 'Execute Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest) do |result|
+        execute_manifest_on(agent, acl_manifest, { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/parameter_target/negative/negative_acl_spec.rb
+++ b/spec/acceptance/parameter_target/negative/negative_acl_spec.rb
@@ -26,7 +26,7 @@ describe 'Parameter Target - Negative' do
     context "Specify Blank Target on #{agent}" do
       target = ''
       it 'Execute Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target), acceptable_exit_codes: [1]) do |result|
+        execute_manifest_on(agent, acl_manifest(target), { :debug => true, :exepect_failures => true }) do |result|
           assert_match(%r{Error:.*(A non-empty name must be specified|Empty string title at)}, result.stderr, 'Expected error was not detected!')
         end
       end
@@ -37,7 +37,7 @@ describe 'Parameter Target - Negative' do
     context "Specify Target with Invalid Path Characters on #{agent}" do
       target = 'c:/temp/invalid_<:>|?*'
       it 'Execute Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target)) do |result|
+        execute_manifest_on(agent, acl_manifest(target), { :debug => true }) do |result|
           assert_match(%r{Error:.*The filename, directory name, or volume label syntax is incorrect},
                        result.stderr, 'Expected error was not detected!')
         end

--- a/spec/acceptance/parameter_target/negative/negative_acl_to_symlink_spec.rb
+++ b/spec/acceptance/parameter_target/negative/negative_acl_to_symlink_spec.rb
@@ -64,7 +64,7 @@ describe 'Negative - Specify Symlink as Target' do
       end
 
       it 'Execute Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest) do |result|
+        execute_manifest_on(agent, acl_manifest, { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/parameter_target/perms_on_dir_8dot3_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_dir_8dot3_spec.rb
@@ -5,7 +5,7 @@ def apply_manifest_and_verify(agent, target, target8dot3, verify_acl_command, re
   context "on #{agent}" do
     acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, target8dot3)) do |result|
+      execute_manifest_on(agent, acl_manifest(target, target8dot3), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -17,7 +17,7 @@ def apply_manifest_and_verify(agent, target, target8dot3, verify_acl_command, re
     end
     if remove
       it 'Execute Remove Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest_remove(target8dot3)) do |result|
+        execute_manifest_on(agent, acl_manifest_remove(target8dot3), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/parameter_target/perms_on_dir_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_dir_spec.rb
@@ -6,7 +6,7 @@ def apply_manifest_and_verify(agent, target, remove = false)
     verify_acl_command = "icacls #{target}"
     acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target)) do |result|
+      execute_manifest_on(agent, acl_manifest(target), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -18,7 +18,7 @@ def apply_manifest_and_verify(agent, target, remove = false)
     end
     if remove
       it 'Execute Remove Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest_remove(target)) do |result|
+        execute_manifest_on(agent, acl_manifest_remove(target), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end
@@ -112,7 +112,7 @@ describe 'Permissions - Directory' do
 
     windows_agents.each do |agent|
       it 'Execute Manifest' do
-        apply_manifest_on(agent, acl_manifest(target), debug: true) do |result|
+        execute_manifest_on(agent, acl_manifest(target), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/parameter_target/perms_on_file_8dot3_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_file_8dot3_spec.rb
@@ -7,7 +7,7 @@ def apply_manifest_and_verify(file_name, target8dot3, file_content, agent, remov
   verify_content_command = "cat /cygdrive/c/temp/#{file_name}"
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(file_name, target8dot3, file_content)) do |result|
+      execute_manifest_on(agent, acl_manifest(file_name, target8dot3, file_content), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -20,7 +20,7 @@ def apply_manifest_and_verify(file_name, target8dot3, file_content, agent, remov
 
     if remove
       it 'Execute Remove Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest_remove(target8dot3)) do |result|
+        execute_manifest_on(agent, acl_manifest_remove(target8dot3), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/parameter_target/perms_on_file_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_file_spec.rb
@@ -7,7 +7,7 @@ def apply_manifest_and_verify(file_name, file_content, agent, remove = nil)
   verify_content_command = "cat /cygdrive/c/temp/#{file_name}"
   context "on #{agent}" do
     it 'Execute Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(file_name, file_content)) do |result|
+      execute_manifest_on(agent, acl_manifest(file_name, file_content), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -20,7 +20,7 @@ def apply_manifest_and_verify(file_name, file_content, agent, remove = nil)
 
     if remove
       it 'Execute Remove Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest_remove(file_name)) do |result|
+        execute_manifest_on(agent, acl_manifest_remove(file_name), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end
@@ -130,7 +130,7 @@ describe 'Permissions - File' do
 
     windows_agents.each do |agent|
       it 'Execute Manifest' do
-        apply_manifest_on(agent, acl_manifest(file_name, file_content), debug: true) do |result|
+        execute_manifest_on(agent, acl_manifest(file_name, file_content), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/propagation/prop_file_spec.rb
+++ b/spec/acceptance/propagation/prop_file_spec.rb
@@ -61,7 +61,7 @@ describe 'Propagate - Negative' do
         agent_version_response = on(agent, puppet('--version')).stdout.chomp
         agent_version = Gem::Version.new(agent_version_response)
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, file_content, rights, prop_type, affects_child_type)) do |result|
+          execute_manifest_on(agent, acl_manifest(target_name, file_content, rights, prop_type, affects_child_type), { :debug => true }) do |result|
             verify_manifest = (agent_version >= Gem::Version.new('5.0.0')) ? verify_manifest_pup5 : verify_manifest_pup4
 
             assert_match(verify_manifest, result.stdout, 'Expected ACL change event not detected!')

--- a/spec/acceptance/propagation/prop_self_all_child_spec.rb
+++ b/spec/acceptance/propagation/prop_self_all_child_spec.rb
@@ -11,7 +11,7 @@ def apply_manifest_and_verify(acl_regex, agent, prop_type, affects_child_type)
     verify_child_acl_command = "icacls #{target_child}"
 
     it 'Execute Apply Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, rights, prop_type, target_child, affects_child_type)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, target_child, affects_child_type), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/propagation/prop_self_no_child_spec.rb
+++ b/spec/acceptance/propagation/prop_self_no_child_spec.rb
@@ -11,7 +11,7 @@ def apply_manifest_and_verify(acl_regex, agent, prop_type)
     verify_child_acl_command = "icacls #{target_child}"
 
     it 'Execute Apply Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, rights, prop_type, target_child)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, target_child), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/propagation/prop_spec.rb
+++ b/spec/acceptance/propagation/prop_spec.rb
@@ -6,7 +6,7 @@ def apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
     target_name = "prop_#{prop_type}_to_#{affects_child_type}"
     verify_acl_command = "icacls #{target_parent}/#{target_name}"
     it 'Execute Apply Manifest' do
-      on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target_name, rights, prop_type, affects_child_type)) do |result|
+      execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, affects_child_type), { :debug => true }) do |result|
         assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/purge/negative/purge_all_perms_dir_spec.rb
+++ b/spec/acceptance/purge/negative/purge_all_perms_dir_spec.rb
@@ -48,7 +48,7 @@ describe 'Purge' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target)) do |result|
+          execute_manifest_on(agent, acl_manifest(target), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -60,7 +60,7 @@ describe 'Purge' do
         end
 
         it 'Attempt to Execute Purge Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: purge_acl_manifest(target), acceptable_exit_codes: [1]) do |result|
+          execute_manifest_on(agent, purge_acl_manifest(target), { :debug => true, :exepect_failures => true }) do |result|
             assert_match(verify_purge_error, result.stderr, 'Expected error was not detected!')
           end
         end

--- a/spec/acceptance/purge/negative/purge_all_perms_file_spec.rb
+++ b/spec/acceptance/purge/negative/purge_all_perms_file_spec.rb
@@ -50,7 +50,7 @@ describe 'Purge' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, file_content), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -62,7 +62,7 @@ describe 'Purge' do
         end
 
         it 'Attempt to Execute Purge Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: purge_acl_manifest(target), acceptable_exit_codes: [1]) do |result|
+          execute_manifest_on(agent, purge_acl_manifest(target), { :debug => true, :exepect_failures => true }) do |result|
             assert_match(verify_purge_error, result.stderr, 'Expected error was not detected!')
           end
         end

--- a/spec/acceptance/purge/purge_all_other_perms_dir_spec.rb
+++ b/spec/acceptance/purge/purge_all_other_perms_dir_spec.rb
@@ -69,7 +69,7 @@ describe 'Purge' do
         end
 
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, user_id1, user_id2)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, user_id1, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -81,7 +81,7 @@ describe 'Purge' do
         end
 
         it 'Execute Purge Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: purge_acl_manifest(target, user_id2)) do |result|
+          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/purge/purge_all_other_perms_file_spec.rb
+++ b/spec/acceptance/purge/purge_all_other_perms_file_spec.rb
@@ -60,7 +60,7 @@ describe 'Purge' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content, user_id1, user_id2)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -72,7 +72,7 @@ describe 'Purge' do
         end
 
         it 'Execute Purge Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: purge_acl_manifest(target, user_id2)) do |result|
+          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/purge/purge_explicit_perms_dir_spec.rb
+++ b/spec/acceptance/purge/purge_explicit_perms_dir_spec.rb
@@ -57,7 +57,7 @@ describe 'Purge' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, user_id1, user_id2)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, user_id1, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -69,7 +69,7 @@ describe 'Purge' do
         end
 
         it 'Execute Purge Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: purge_acl_manifest(target, user_id2)) do |result|
+          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/purge/purge_explicit_perms_file_spec.rb
+++ b/spec/acceptance/purge/purge_explicit_perms_file_spec.rb
@@ -61,7 +61,7 @@ describe 'Purge' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content, user_id1, user_id2)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -73,7 +73,7 @@ describe 'Purge' do
         end
 
         it 'Execute Purge Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: purge_acl_manifest(target, user_id2)) do |result|
+          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/use_cases/complex_prop_inherit_spec.rb
+++ b/spec/acceptance/use_cases/complex_prop_inherit_spec.rb
@@ -143,7 +143,7 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(group1, group2, user_id1, user_id2, target, target_child, target_grand_child, file_content)) do |result|
+          execute_manifest_on(agent, acl_manifest(group1, group2, user_id1, user_id2, target, target_child, target_grand_child, file_content), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/use_cases/grant_full_deny_full_spec.rb
+++ b/spec/acceptance/use_cases/grant_full_deny_full_spec.rb
@@ -58,7 +58,7 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, target_child, file_content, group, user_id)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, target_child, file_content, group, user_id), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
@@ -71,7 +71,7 @@ describe 'Use Cases' do
         end
 
         it 'Attempt to Update File' do
-          on(agent, puppet('apply', '--debug'), stdin: update_manifest(target_child)) do |result|
+          execute_manifest_on(agent, update_manifest(target_child), { :debug => true }) do |result|
             assert_match(%r{Error:}, result.stderr, 'Expected error was not detected!')
           end
         end

--- a/spec/acceptance/use_cases/multiple_aces_spec.rb
+++ b/spec/acceptance/use_cases/multiple_aces_spec.rb
@@ -94,7 +94,7 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/use_cases/multiple_acls_shared_ident_spec.rb
+++ b/spec/acceptance/use_cases/multiple_acls_shared_ident_spec.rb
@@ -111,7 +111,7 @@ describe 'Use Cases' do
 
     windows_agents.each do |agent|
       it 'Execute ACL Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, target_child, target_grand_child, group1, group2, user_id1, user_id2)) do |result|
+        execute_manifest_on(agent, acl_manifest(target, target_child, target_grand_child, group1, group2, user_id1, user_id2), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/use_cases/multiple_acls_spec.rb
+++ b/spec/acceptance/use_cases/multiple_acls_spec.rb
@@ -104,7 +104,7 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, target_child, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, target_child, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/use_cases/negative/allow_deny_ident_spec.rb
+++ b/spec/acceptance/use_cases/negative/allow_deny_ident_spec.rb
@@ -35,7 +35,7 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, file_content), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end

--- a/spec/acceptance/use_cases/negative/locked_resource_spec.rb
+++ b/spec/acceptance/use_cases/negative/locked_resource_spec.rb
@@ -41,13 +41,13 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
-          on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content)) do |result|
+          execute_manifest_on(agent, acl_manifest(target, file_content), { :debug => true }) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
 
         it 'Attempt to Update File' do
-          on(agent, puppet('apply', '--debug'), stdin: update_manifest(target)) do |result|
+          execute_manifest_on(agent, update_manifest(target), { :debug => true }) do |result|
             assert_match(%r{Error:.*Permission denied}, result.stderr, 'Expected error was not detected!')
           end
         end

--- a/spec/acceptance/use_cases/negative/multi_acl_single_target_spec.rb
+++ b/spec/acceptance/use_cases/negative/multi_acl_single_target_spec.rb
@@ -43,7 +43,7 @@ describe 'Use Cases' do
 
     windows_agents.each do |agent|
       it 'Execute ACL Manifest' do
-        on(agent, puppet('apply', '--debug'), stdin: acl_manifest(target, file_content)) do |result|
+        execute_manifest_on(agent, acl_manifest(target, file_content), { :debug => true }) do |result|
           assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,8 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
+require 'beaker/testmode_switcher'
+require 'beaker/testmode_switcher/dsl'
 
 run_puppet_install_helper
 


### PR DESCRIPTION
This updates the acl module to use testmode switcher instead of direct agent calls.

Only places where a manifest was executed were methods changed (i.e. `on(` to `execute_manifest` or `execute_manifest_on`).

Outputting `debug` messages were maintained by setting `debug => true` option.

In some cases where specific exit codes were tracked, the following reference was followed: https://github.com/puppetlabs/beaker-testmode_switcher/blob/f91829ee5fddd04b633ea8d531485e5f0f7cc996/lib/beaker/testmode_switcher/runner_base.rb#L19-L22

