### PR TITLE
(maint) Add win2016 to metadata.json compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,6 +30,7 @@
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
+        "Server 2016",
         "7",
         "8",
         "10"


### PR DESCRIPTION
This commit updates the metadata.json compatibility section to include
Windows Server 2016.