### PR TITLE
(PDK-1037) Remove the rspec-puppet pin from Gemfile

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,10 +3,6 @@ Rakefile:
   unmanaged: true
 Gemfile:
   optional:
-    ':development':
-      - gem: 'rspec-puppet'
-        platforms: ["mswin", "mingw", "x64_mingw"]
-        version: '< 2.6.0'
     ':system_tests':
       - gem: beaker-testmode_switcher
         version: '~> 0.4'

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development do
   gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "rspec-puppet", '< 2.6.0',                          :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
 end
 
 group :system_tests do


### PR DESCRIPTION
The monkeypatches introduced by rspec-puppet are now properly contained
to rspec-puppet examples as of rodjek/rspec-puppet#578. With this fixed,
this module can now start pulling in rspec-puppet updates via the
puppet-module metagems again.