### PR TITLE
(maint) Add beaker 4.0 dependency serverspec to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :system_tests do
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "serverspec", '~> 2.39'
   gem "beaker-testmode_switcher", '~> 0.4',                                      :require => false
   gem 'master_manipulator',                                                      :require => false
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false


### PR DESCRIPTION
This is a dependency beaker dropped upon the release of v4.0, but we
still need it for tests to work.