### PR TITLE
DO NOT MERGE: (maint) Pin beaker version to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')                  
   gem "beaker-pe",                                                               :require => false
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])


### PR DESCRIPTION
With the recent release of beaker 4.0, the beaker-rspec gem needs to be
updated to declare compatability with beaker 4.0, and otherwise will not
install. In the meantime we need to pin beaker to 3.x.