### PR TITLE
pdksync - (MODULES-7658) use beaker4 in puppet-module-gems

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+require 'beaker-puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
@@ -5,6 +7,7 @@ require 'beaker/testmode_switcher'
 require 'beaker/testmode_switcher/dsl'
 
 run_puppet_install_helper
+configure_type_defaults_on(hosts)
 
 install_ca_certs
 


### PR DESCRIPTION
(MODULES-7658) use beaker4 in puppet-module-gems
pdk version: `1.6.0` 
