### PR TITLE
(MODULES-8058) Remove changelog entry for 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Feature release including support for Windows Server 2016 and Puppet 6
 
 #### Bug Fixes
 
-- Fixed issue with emitting change messages in Puppet 5 ([MODULES-5364](https://tickets.puppetlabs.com/browse/MODULES-5364))
 - Update tests for Unicode on Windows
 - Convert acceptance tests to rspec format ([MODULES-5978](https://tickets.puppetlabs.com/browse/MODULES-5978))
 - Update module to conform with rubocop ([MODULES-5899](https://tickets.puppetlabs.com/browse/MODULES-5899))


### PR DESCRIPTION
Previously there was a changelog entry for v2.1.0 related to MODULES-5364. It
was accidentally merged prior to a conversation being had over whether this
should be included.  The result was this should not be in the changelog.  This
commit removes this entry from the changelog prior to release.
