### PR TITLE
(FM-7693) Add Windows Server 2019

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,7 @@
         "Server 2012",
         "Server 2012 R2",
         "Server 2016",
+        "Server 2019",
         "7",
         "8",
         "10"


### PR DESCRIPTION
The acl module now supports Windows Server 2019.  This commit
updates the metadata.json to show that Server 2019 is supported.