### PR TITLE
(MODULES-9294) Updates to acceptance tests

### DIFF
--- a/spec/acceptance/access_rights_directory/allow_rights_dir_spec.rb
+++ b/spec/acceptance/access_rights_directory/allow_rights_dir_spec.rb
@@ -5,13 +5,13 @@ def apply_manifest_with_rights(acl_regex, agent, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(target, rights), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(target)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
   end

--- a/spec/acceptance/access_rights_directory/allow_rights_dir_spec.rb
+++ b/spec/acceptance/access_rights_directory/allow_rights_dir_spec.rb
@@ -1,24 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_with_rights(acl_regex, agent, rights, target)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(target, rights), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(target)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-  end
-end
-
 describe 'Directory - Allow' do
-  def acl_manifest(target, rights)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -44,88 +27,85 @@ describe 'Directory - Allow' do
     MANIFEST
   end
 
-  def verify_acl_command(target)
-    "icacls #{target}"
-  end
+  let(:verify_acl_command) { "icacls #{target}" }
 
   context '"execute" Rights for Identity on Directory' do
-    rights = 'execute'
-    target = "c:/temp/allow_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(Rc,S,X,RA\)}
+    let(:rights) { 'execute' }
+    let(:target) { "c:/temp/allow_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(Rc,S,X,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"modify" Rights for Identity on Directory' do
-    rights = 'modify'
-    target = "c:/temp/allow_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(M\)}
+    let(:rights) { 'modify' }
+    let(:target) { "c:/temp/allow_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(M\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"read, execute" Rights for Identity on Directory' do
-    rights = "read', 'execute"
-    target = 'c:/temp/allow_re_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(RX\)}
+    let(:rights) { "read', 'execute" }
+    let(:target) { 'c:/temp/allow_re_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(RX\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"read" Rights for Identity on Directory' do
-    rights = 'read'
-    target = "c:/temp/allow_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(R\)}
+    let(:rights) { 'read' }
+    let(:target) { "c:/temp/allow_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(R\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write, execute" Rights for Identity on Directory' do
-    rights = "write','execute"
-    target = 'c:/temp/allow_we_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(W,Rc,X,RA\)}
+    let(:rights) { "write','execute" }
+    let(:target) { 'c:/temp/allow_we_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(W,Rc,X,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write, read" Rights for Identity on Directory' do
-    rights = "write','read"
-    target = 'c:/temp/allow_wr_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(R,W\)}
+    let(:rights) { "write','read" }
+    let(:target) { 'c:/temp/allow_wr_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(R,W\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write, read, execute" Rights for Identity on Directory' do
-    rights = "write','read','execute"
-    target = 'c:/temp/allow_wre_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(RX,W\)}
+    let(:rights) { "write','read','execute" }
+    let(:target) { 'c:/temp/allow_wre_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(RX,W\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write" Rights for Identity on Directory' do
-    rights = 'write'
-    target = "c:/temp/allow_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(W,Rc\)}
+    let(:rights) { 'write' }
+    let(:target) { "c:/temp/allow_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(W,Rc\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/access_rights_directory/deny_rights_dir_spec.rb
+++ b/spec/acceptance/access_rights_directory/deny_rights_dir_spec.rb
@@ -5,13 +5,13 @@ def apply_manifest_with_rights(acl_regex, agent, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(target, rights), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(target)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
   end

--- a/spec/acceptance/access_rights_directory/deny_rights_dir_spec.rb
+++ b/spec/acceptance/access_rights_directory/deny_rights_dir_spec.rb
@@ -1,24 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_with_rights(acl_regex, agent, rights, target)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(target, rights), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(target)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-  end
-end
-
 describe 'Directory - Deny' do
-  def acl_manifest(target, rights)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -44,98 +27,95 @@ describe 'Directory - Deny' do
     MANIFEST
   end
 
-  def verify_acl_command(target)
-    "icacls #{target}"
-  end
+  let(:verify_acl_command) { "icacls #{target}" }
 
   context '"execute" Rights for Identity on Directory' do
-    rights = 'execute'
-    target = "c:/temp/deny_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(Rc,S,X,RA\)}
+    let(:rights) { 'execute' }
+    let(:target) { "c:/temp/deny_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(Rc,S,X,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"full" Rights for Identity on Directory' do
-    rights = 'full'
-    target = "c:/temp/deny_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(N\)}
+    let(:rights) { 'full' }
+    let(:target) { "c:/temp/deny_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(N\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"modify" Rights for Identity on Directory' do
-    rights = 'modify'
-    target = "c:/temp/deny_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(M\)}
+    let(:rights) { 'modify' }
+    let(:target) { "c:/temp/deny_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(M\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"read, execute" Rights for Identity on Directory' do
-    rights = "read', 'execute"
-    target = 'c:/temp/deny_re_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(RX\)}
+    let(:rights) { "read', 'execute" }
+    let(:target) { 'c:/temp/deny_re_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(RX\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"read" Rights for Identity on Directory' do
-    rights = 'read'
-    target = "c:/temp/deny_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(R\)}
+    let(:rights) { 'read' }
+    let(:target) { "c:/temp/deny_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(R\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write, execute" Rights for Identity on Directory' do
-    rights = "write','execute"
-    target = 'c:/temp/deny_we_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(W,Rc,X,RA\)}
+    let(:rights) { "write','execute" }
+    let(:target) { 'c:/temp/deny_we_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(W,Rc,X,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write, read" Rights for Identity on Directory' do
-    rights = "write','read"
-    target = 'c:/temp/deny_wr_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(R,W\)}
+    let(:rights) { "write','read" }
+    let(:target) { 'c:/temp/deny_wr_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(R,W\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write, read, execute" Rights for Identity on Directory' do
-    rights = "write','read','execute"
-    target = 'c:/temp/deny_wre_rights_dir'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(RX,W\)}
+    let(:rights) { "write','read','execute" }
+    let(:target) { 'c:/temp/deny_wre_rights_dir' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(RX,W\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"write" Rights for Identity on Directory' do
-    rights = 'write'
-    target = "c:/temp/deny_#{rights}_rights_dir"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(W,Rc\)}
+    let(:rights) { 'write' }
+    let(:target) { "c:/temp/deny_#{rights}_rights_dir" }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(W,Rc\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_with_rights(acl_regex, agent, rights, target)
+      include_examples 'execute manifest', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/access_rights_directory/mask_specific/allow_rights_dir_mask_spec.rb
+++ b/spec/acceptance/access_rights_directory/mask_specific/allow_rights_dir_mask_spec.rb
@@ -1,24 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def execute_manifest_with_mask(acl_regex, agent, mask)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(mask), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(mask)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-  end
-end
-
 describe 'Allow Mask Specific' do
-  def acl_manifest(mask)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -44,53 +27,51 @@ describe 'Allow Mask Specific' do
     MANIFEST
   end
 
-  def verify_acl_command(mask)
-    "icacls c:/temp/allow_#{mask}_rights_dir"
-  end
+  let(:target) { "c:/temp/allow_#{mask}_rights_dir" }
+  let(:verify_acl_command) { "icacls #{target}" }
 
   context '"AD, S, WA, X" Rights for Identity on Directory' do
-    mask = '1048868'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(S,AD,X,WA\)}
+    let(:mask) { '1048868' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(S,AD,X,WA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"RD, DC, WEA, RC" Rights for Identity on Directory' do
-    mask = '131153'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(Rc,RD,WEA,DC\)}
+    let(:mask) { '131153' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(Rc,RD,WEA,DC\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"S, DE, REA, WEA, RA, WA" Rights for Identity on Directory' do
-    mask = '1114520'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(D,REA,WEA,RA,WA\)}
+    let(:mask) { '1114520' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(D,REA,WEA,RA,WA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"S, RA, WA, RC" Rights for Identity on Directory' do
-    mask = '1180032'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(Rc,S,RA,WA\)}
+    let(:mask) { '1180032' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(Rc,S,RA,WA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"WD, REA, RA, S" Rights for Identity on Directory' do
-    mask = '1048714'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(S,WD,REA,RA\)}
+    let(:mask) { '1048714' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(S,WD,REA,RA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/access_rights_directory/mask_specific/allow_rights_dir_mask_spec.rb
+++ b/spec/acceptance/access_rights_directory/mask_specific/allow_rights_dir_mask_spec.rb
@@ -5,13 +5,13 @@ def execute_manifest_with_mask(acl_regex, agent, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(mask), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(mask)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
   end

--- a/spec/acceptance/access_rights_directory/mask_specific/deny_rights_dir_mask_spec.rb
+++ b/spec/acceptance/access_rights_directory/mask_specific/deny_rights_dir_mask_spec.rb
@@ -5,13 +5,13 @@ def execute_manifest_with_mask(acl_regex, agent, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(mask), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(mask)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
   end

--- a/spec/acceptance/access_rights_directory/mask_specific/deny_rights_dir_mask_spec.rb
+++ b/spec/acceptance/access_rights_directory/mask_specific/deny_rights_dir_mask_spec.rb
@@ -1,24 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def execute_manifest_with_mask(acl_regex, agent, mask)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(mask), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(mask)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-  end
-end
-
 describe 'Directory - Deny Mask Specific' do
-  def acl_manifest(mask)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -44,52 +27,51 @@ describe 'Directory - Deny Mask Specific' do
     MANIFEST
   end
 
-  def verify_acl_command(mask)
-    "icacls c:/temp/deny_#{mask}_rights_dir"
-  end
+  let(:target) { "c:/temp/deny_#{mask}_rights_dir" }
+  let(:verify_acl_command) { "icacls #{target}" }
 
   context '"AD, S, WA, X" Rights for Identity on Directory' do
-    mask = '1048868'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(S,AD,X,WA\)}
+    let(:mask) { '1048868' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(S,AD,X,WA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"DE, REA, WEA, RA, WA" Rights for Identity on Directory' do
-    mask = '65944'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(D,REA,WEA,RA,WA\)}
+    let(:mask) { '65944' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(D,REA,WEA,RA,WA\)} }
+
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"RD, S, DC, WEA, RC" Rights for Identity on Directory' do
-    mask = '131153'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(Rc,S,RD,WEA,DC\)}
+    let(:mask) { '131153' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(Rc,S,RD,WEA,DC\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"S, RA, WA, Rc" Rights for Identity on Directory' do
-    mask = '1180032'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(Rc,S,RA,WA\)}
+    let(:mask) { '1180032' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(Rc,S,RA,WA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 
   context '"WD, REA, RA, S" Rights for Identity on File' do
-    mask = '1048714'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(S,WD,REA,RA\)}
+    let(:mask) { '1048714' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(DENY\)\(S,WD,REA,RA\)} }
 
     windows_agents.each do |agent|
-      execute_manifest_with_mask(acl_regex, agent, mask)
+      include_examples 'execute manifest', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/access_rights_file/allow_rights_file_spec.rb
+++ b/spec/acceptance/access_rights_file/allow_rights_file_spec.rb
@@ -5,19 +5,19 @@ def apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(target, rights, file_content), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(target)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(target)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/access_rights_file/deny_rights_file_spec.rb
+++ b/spec/acceptance/access_rights_file/deny_rights_file_spec.rb
@@ -5,19 +5,19 @@ def apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(target, rights, file_content), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(target)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(target)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/access_rights_file/deny_rights_file_spec.rb
+++ b/spec/acceptance/access_rights_file/deny_rights_file_spec.rb
@@ -1,36 +1,13 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(target, rights, file_content), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(target)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command(target)) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'File - Deny' do
-  def acl_manifest(target, rights, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
       }
 
-      file { '#{target}':
+      file { '#{target_parent}/#{target_file}':
         ensure  => file,
         content => '#{file_content}',
         require => File['#{target_parent}']
@@ -43,7 +20,7 @@ describe 'File - Deny' do
         password   => "L0v3Pupp3t!"
       }
 
-      acl { '#{target}':
+      acl { '#{target_parent}/#{target_file}':
         permissions  => [
           { identity => '#{user_id}', perm_type => 'deny', rights => ['#{rights}'] },
         ],
@@ -51,112 +28,106 @@ describe 'File - Deny' do
     MANIFEST
   end
 
-  def verify_content_command(target)
-    target = target[3..-1] # remove the leading 'c:/' from the target
-    "cat /cygdrive/c/#{target}"
-  end
+  let(:verify_acl_command) { "icacls #{target_parent}/#{target_file}" }
 
-  def verify_acl_command(target)
-    "icacls #{target}"
-  end
+  let(:verify_content_path) { "#{target_parent}/#{target_file}" }
 
   context '"execute" Rights for Identity on File' do
-    rights = 'execute'
-    file_content = 'Smells like teen spirit or body odor.'
-    target = "c:/temp/deny_#{rights}_rights_file.txt"
-    acl_regex = %r{.*\\bob:\(DENY\)\(Rc,S,X,RA\)}
+    let(:rights) { 'execute' }
+    let(:file_content) { 'Smells like teen spirit or body odor.' }
+    let(:target_file) { "deny_#{rights}_rights_file.txt" }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(Rc,S,X,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"full" Rights for Identity on File' do
-    rights = 'full'
-    target = "c:/temp/deny_#{rights}_rights_file.txt"
-    file_content = 'You have to fight for your right to party.'
-    acl_regex = %r{.*\\bob:\(N\)}
+    let(:rights) { 'full' }
+    let(:target_file) { "deny_#{rights}_rights_file.txt" }
+    let(:file_content) { 'You have to fight for your right to party.' }
+    let(:acl_regex) { %r{.*\\bob:\(N\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"modify" Rights for Identity on File' do
-    rights = 'modify'
-    target = "c:/temp/deny_#{rights}_rights_file.txt"
-    file_content = 'Giant flying space pigs with lasers.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(M\)}
+    let(:rights) { 'modify' }
+    let(:target_file) { "deny_#{rights}_rights_file.txt" }
+    let(:file_content) { 'Giant flying space pigs with lasers.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(M\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"read, execute" Rights for Identity on File' do
-    rights = "read','execute"
-    target = 'c:/temp/deny_re_rights_file.txt'
-    file_content = 'Your forcefield is good, but my teleporting is better.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(RX\)}
+    let(:rights) { "read','execute" }
+    let(:target_file) { 'deny_re_rights_file.txt' }
+    let(:file_content) { 'Your forcefield is good, but my teleporting is better.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(RX\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"read" Rights for Identity on File' do
-    rights = 'read'
-    target = "c:/temp/deny_#{rights}_rights_file.txt"
-    file_content = 'Elvis is king of rock and roll.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(R\)}
+    let(:rights) { 'read' }
+    let(:target_file) { "deny_#{rights}_rights_file.txt" }
+    let(:file_content) { 'Elvis is king of rock and roll.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(R\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"write, execute" Rights for Identity on File' do
-    rights = "write','execute"
-    target = 'c:/temp/deny_we_rights_file.txt'
-    file_content = 'Now time for some rocket fuel.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(W,Rc,X,RA\)}
+    let(:rights) { "write','execute" }
+    let(:target_file) { 'deny_we_rights_file.txt' }
+    let(:file_content) { 'Now time for some rocket fuel.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(W,Rc,X,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"write, read" Rights for Identity on File' do
-    rights = "write','read"
-    target = 'c:/temp/deny_wr_rights_file.txt'
-    file_content = 'I live in a garbage can.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(R,W\)}
+    let(:rights) { "write','read" }
+    let(:target_file) { 'deny_wr_rights_file.txt' }
+    let(:file_content) { 'I live in a garbage can.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(R,W\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"write, read, execute" Rights for Identity on File' do
-    rights = "write','read','execute"
-    target = 'c:/temp/deny_wre_rights_file.txt'
-    file_content = 'Flying rats.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(RX,W\)}
+    let(:rights) { "write','read','execute" }
+    let(:target_file) { 'deny_wre_rights_file.txt' }
+    let(:file_content) { 'Flying rats.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(RX,W\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"write" Rights for Identity on File' do
-    rights = 'write'
-    target = "c:/temp/deny_#{rights}_rights_file.txt"
-    file_content = 'Marxist cat wants some of your food.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(W,Rc\)}
+    let(:rights) { 'write' }
+    let(:target_file) { "deny_#{rights}_rights_file.txt" }
+    let(:file_content) { 'Marxist cat wants some of your food.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(W,Rc\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, rights, target)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/access_rights_file/mask_specific/allow_rights_file_mask_spec.rb
+++ b/spec/acceptance/access_rights_file/mask_specific/allow_rights_file_mask_spec.rb
@@ -1,30 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(acl_regex, agent, file_content, mask)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(mask, file_content), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(mask)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command(mask)) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'File - Allow Mask Specific' do
-  def acl_manifest(mask, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -51,62 +28,57 @@ describe 'File - Allow Mask Specific' do
     MANIFEST
   end
 
-  def verify_acl_command(mask)
-    "icacls c:/temp/allow_#{mask}_rights_file.txt"
-  end
+  let(:verify_acl_command) { "icacls c:/temp/allow_#{mask}_rights_file.txt" }
 
-  def verify_content_command(mask)
-    "cat /cygdrive/c/temp/allow_#{mask}_rights_file.txt"
-  end
+  let(:verify_content_path) { "c:\\temp\\allow_#{mask}_rights_file.txt" }
 
   context '"AD, S, WA, X" Rights for Identity on File' do
-    mask = '1048868'
-    file_content = 'The puppets are controlling my mind!'
-    acl_regex = %r{.*\\bob:\(S,AD,X,WA\)}
+    let(:mask) { '1048868' }
+    let(:file_content) { 'The puppets are controlling my mind!' }
+    let(:acl_regex) { %r{.*\\bob:\(S,AD,X,WA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"RD, DE, WEA, RC" Rights for Identity on File' do
-    mask = '196625'
-    file_content = 'You are never going to feel it!'
-    acl_regex = %r{.*\\bob:\(DE,Rc,RD,WEA\)}
+    let(:mask) { '196625' }
+    let(:file_content) { 'You are never going to feel it!' }
+    let(:acl_regex) { %r{.*\\bob:\(DE,Rc,RD,WEA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"S, DE, REA, WEA, RA, WA" Rights for Identity on File' do
-    mask = '1114520'
-    file_content = 'Karate time!'
-    acl_regex = %r{.*\\bob:\(D,REA,WEA,RA,WA\)}
+    let(:mask) { '1114520' }
+    let(:file_content) { 'Karate time!' }
+    let(:acl_regex) { %r{.*\\bob:\(D,REA,WEA,RA,WA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"S, RA, WA, RC" Rights for Identity on File' do
-    mask = '1180032'
-    file_content = 'I like shoes made by Canadians.'
-    acl_regex = %r{.*\\bob:\(Rc,S,RA,WA\)}
+    let(:mask) { '1180032' }
+    let(:file_content) { 'I like shoes made by Canadians.' }
+    let(:acl_regex) { %r{.*\\bob:\(Rc,S,RA,WA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"WD, REA, RA, S" Rights for Identity on File' do
-    mask = '1048714'
-    file_content = 'My mind is going... I can feel it.'
-    acl_regex = %r{.*\\bob:\(S,WD,REA,RA\)}
+    let(:mask) { '1048714' }
+    let(:file_content) { 'My mind is going... I can feel it.' }
+    let(:acl_regex) { %r{.*\\bob:\(S,WD,REA,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/access_rights_file/mask_specific/allow_rights_file_mask_spec.rb
+++ b/spec/acceptance/access_rights_file/mask_specific/allow_rights_file_mask_spec.rb
@@ -5,19 +5,19 @@ def apply_manifest_and_verify(acl_regex, agent, file_content, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(mask, file_content), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(mask)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(mask)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/access_rights_file/mask_specific/deny_rights_file_mask_spec.rb
+++ b/spec/acceptance/access_rights_file/mask_specific/deny_rights_file_mask_spec.rb
@@ -5,19 +5,19 @@ def apply_manifest_and_verify(acl_regex, agent, file_content, mask)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(mask, file_content), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(mask)) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(mask)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/access_rights_file/mask_specific/deny_rights_file_mask_spec.rb
+++ b/spec/acceptance/access_rights_file/mask_specific/deny_rights_file_mask_spec.rb
@@ -1,30 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(acl_regex, agent, file_content, mask)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(mask, file_content), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(mask)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command(mask)) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'File - Deny Mask Specific' do
-  def acl_manifest(mask, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -51,62 +28,57 @@ describe 'File - Deny Mask Specific' do
     MANIFEST
   end
 
-  def verify_acl_command(mask)
-    "icacls c:/temp/deny_#{mask}_rights_file.txt"
-  end
+  let(:verify_acl_command) { "icacls c:/temp/deny_#{mask}_rights_file.txt" }
 
-  def verify_content_command(mask)
-    "cat /cygdrive/c/temp/deny_#{mask}_rights_file.txt"
-  end
+  let(:verify_content_path) { "c:\\temp\\deny_#{mask}_rights_file.txt" }
 
   context '"AD, S, WA, X" Rights for Identity on File' do
-    mask = '1048868'
-    file_content = 'Slippery when dry.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(S,AD,X,WA\)}
+    let(:mask) { '1048868' }
+    let(:file_content) { 'Slippery when dry.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(S,AD,X,WA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"RD, DE, WEA, RC" Rights for Identity on File' do
-    mask = '196625'
-    file_content = 'Pressure, oh the pressure.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(D,Rc,RD,WEA\)}
+    let(:mask) { '196625' }
+    let(:file_content) { 'Pressure, oh the pressure.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(D,Rc,RD,WEA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"S, DE, REA, WEA, RA, WA" Rights for Identity on File' do
-    mask = '1114520'
-    file_content = 'Gallons of hats on your head.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(D,REA,WEA,RA,WA\)}
+    let(:mask) { '1114520' }
+    let(:file_content) { 'Gallons of hats on your head.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(D,REA,WEA,RA,WA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"S, RA, WA, RC" Rights for Identity on File' do
-    mask = '1180032'
-    file_content = 'We need experienced fighter pilots to train these pigs in the basics of aviation!'
-    acl_regex = %r{.*\\bob:\(DENY\)\(Rc,S,RA,WA\)}
+    let(:mask) { '1180032' }
+    let(:file_content) { 'We need experienced fighter pilots to train these pigs in the basics of aviation!' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(Rc,S,RA,WA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context '"WD, REA, RA, S" Rights for Identity on File' do
-    mask = '1048714'
-    file_content = 'Tiny little people with small problems.'
-    acl_regex = %r{.*\\bob:\(DENY\)\(S,WD,REA,RA\)}
+    let(:mask) { '1048714' }
+    let(:file_content) { 'Tiny little people with small problems.' }
+    let(:acl_regex) { %r{.*\\bob:\(DENY\)\(S,WD,REA,RA\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, file_content, mask)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/basic_functionality/negative/negative_acl_on_linux_spec.rb
+++ b/spec/acceptance/basic_functionality/negative/negative_acl_on_linux_spec.rb
@@ -17,7 +17,7 @@ describe 'Basic Functionality - Negative' do
     linux_agents.each do |agent|
       it "Verify that the 'acl' Type Does not Work on Non-Windows Agents on #{agent}" do
         execute_manifest_on(agent, acl_manifest, debug: true) do |result|
-          assert_match(%r{Error: Could not find a suitable provider for acl}, result.stderr, 'Expected error was not detected!')
+          expect(result.stderr).to match(%r{Error: Could not find a suitable provider for acl})
         end
       end
     end

--- a/spec/acceptance/basic_functionality/negative/negative_acl_on_linux_spec.rb
+++ b/spec/acceptance/basic_functionality/negative/negative_acl_on_linux_spec.rb
@@ -1,21 +1,23 @@
 require 'spec_helper_acceptance'
 
 describe 'Basic Functionality - Negative' do
-  acl_manifest = <<-MANIFEST
-    file { '/tmp/acl_test':
-      ensure => directory
-    }
+  let(:acl_manifest) do
+    <<-MANIFEST
+      file { '/tmp/acl_test':
+        ensure => directory
+      }
 
-    acl { '/tmp/acl_test':
-      permissions => [
-        { identity => 'root', rights => ['full'] },
-      ],
-    }
-  MANIFEST
+      acl { '/tmp/acl_test':
+        permissions => [
+          { identity => 'root', rights => ['full'] },
+        ],
+      }
+    MANIFEST
+  end
 
   context 'ACL Fails Gracefully on Linux' do
     linux_agents.each do |agent|
-      it "Verify that the 'acl' Type Does not Work on Non-Windows Agents on #{agent}" do
+      it "verifes that the 'acl' type does not work on non-Windows agents on #{agent}, raises error" do
         execute_manifest_on(agent, acl_manifest, debug: true) do |result|
           expect(result.stderr).to match(%r{Error: Could not find a suitable provider for acl})
         end

--- a/spec/acceptance/group/group_local_spec.rb
+++ b/spec/acceptance/group/group_local_spec.rb
@@ -1,30 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(agent, file_content, group_id, _group_regex, user_type)
-  context "on #{agent}" do
-    it 'Execute ACL Manifest' do
-      execute_manifest_on(agent, acl_manifest(user_type, file_content, group_id), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_group_command(user_type)) do |result|
-        expect(result.stdout).not_to match(%r{#{acl_regex}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command(user_type)) do |result|
-        expect(result.stdout).not_to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Group' do
-  def acl_manifest(user_type, file_content, group_id)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -68,58 +45,55 @@ describe 'Group' do
     MANIFEST
   end
 
-  def verify_group_command(user_type)
-    "icacls #{target_parent}/group_#{user_type}.txt"
-  end
+  let(:verify_acl_command) { "icacls #{target_parent}/group_#{user_type}.txt" }
 
-  def verify_content_command(user_type)
-    "cat /cygdrive/c/temp/group_#{user_type}.txt"
-  end
+  let(:verify_content_path) { "#{target_parent}/group_#{user_type}.txt" }
 
   context 'Change Group to Local Group' do
-    user_type = 'local_group'
-    file_content = 'Hot sand in your eyes!'
-    group_id = 'jerks'
-    group_regex = %r{.*\\jerks:\(M\)}
+    let(:user_type) {  'local_group' }
+    let(:file_content) { 'Hot sand in your eyes!' }
+    let(:group_id) { 'jerks' }
+    let(:acl_regex) { %r{.*\\jerks:\(M\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, file_content, group_id, group_regex, user_type)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Change Group to Local Group with Long Name' do
-    user_type = 'local_long_group_name'
-    file_content = 'Uncontrolled napping.'
+    let(:user_type) {  'local_long_group_name' }
+    let(:file_content) { 'Uncontrolled napping.' }
     # rubocop:disable Metrics/LineLength
-    group_id = 'jasqddweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg'
-    group_regex = %r{.*\\jasqddweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg:\(M\)}
+    let(:group_id) { 'jasqddweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg' }
+    let(:acl_regex) { %r{.*\\jasqddweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg:\(M\)} }
+
     # rubocop:enable Metrics/LineLength
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, file_content, group_id, group_regex, user_type)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Change Group to Local User with Long Name' do
-    user_type = 'local_long_user_name'
-    file_content = 'Dog eat dog world.'
-    group_id = 'long_user_name_jerry'
-    group_regex = %r{.*\\long_user_name_jerry:\(M\)}
+    let(:user_type) {  'local_long_user_name' }
+    let(:file_content) { 'Dog eat dog world.' }
+    let(:group_id) { 'long_user_name_jerry' }
+    let(:acl_regex) { %r{.*\\long_user_name_jerry:\(M\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, file_content, group_id, group_regex, user_type)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Change Group to Local User' do
-    user_type = 'local_user'
-    file_content = 'cat-man-doo!'
-    group_id = generate_random_username
-    group_regex = %r{.*\\#{group_id}:\(M\)}
+    random_username = generate_random_username
+    let(:user_type) {  'local_user' }
+    let(:file_content) { 'cat-man-doo!' }
+    let(:group_id) { random_username }
+    let(:acl_regex) { %r{.*\\#{group_id}:\(M\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, file_content, group_id, group_regex, user_type)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/group/group_local_spec.rb
+++ b/spec/acceptance/group/group_local_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper_acceptance'
 
 # rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(agent, file_content, group_id, group_regex, user_type)
+def apply_manifest_and_verify(agent, file_content, group_id, _group_regex, user_type)
   context "on #{agent}" do
     it 'Execute ACL Manifest' do
       execute_manifest_on(agent, acl_manifest(user_type, file_content, group_id), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_group_command(user_type)) do |result|
-        assert_match(group_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).not_to match(%r{#{acl_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(user_type)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).not_to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/group/group_local_unicode_group_spec.rb
+++ b/spec/acceptance/group/group_local_unicode_group_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper_acceptance'
 
+prefix = SecureRandom.uuid.to_s
+
 describe 'Group - Unicode' do
-  def acl_manifest(prefix, file_content, group_id)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -42,36 +44,20 @@ describe 'Group - Unicode' do
         group           => '#{group_id}',
         inherit_parent_permissions => 'false'
       }
-      MANIFEST
+    MANIFEST
   end
 
-  def verify_group_command(prefix, raw_group_id)
-    "(Get-ACL 'c:/temp/#{prefix}.txt' | Where-Object { $_.Group -match ('.*\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) } | Measure-Object).Count"
-  end
-
-  def verify_content_command(user_type)
-    "cat /cygdrive/c/group_#{user_type}.txt"
-  end
+  let(:verify_acl_command) { "(Get-ACL 'c:/temp/#{prefix}.txt' | Where-Object { $_.Group -match ('.*\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) } | Measure-Object).Count" }
+  let(:acl_regex) { %r{^1$} }
 
   context 'Change Group to Local Unicode Group' do
-    prefix = SecureRandom.uuid.to_s
-    file_content = 'Dangers driving drunk while insane.'
-    raw_group_id = 'group_\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE'
-    group_id = "group_\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE" # 䎈含㴼罍率䎁叴秀㪲軞
+    let(:file_content) { 'Dangers driving drunk while insane.' }
+    let(:raw_group_id) { 'group_\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE' }
+    let(:group_id) { "group_\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE" } # 䎈含㴼罍率䎁叴秀㪲軞
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(prefix, file_content, group_id), debug: true) do |result|
-            expect(result.stderr).not_to match(%r{Error:})
-          end
-        end
-
-        it 'Verify that ACL Rights are Correct' do
-          on(agent, powershell(verify_group_command(prefix, raw_group_id), 'EncodedCommand' => true)) do |result|
-            expect(result.stdout).to match(%r{^1$})
-          end
-        end
+        include_examples 'execute manifest and verify (with PowerShell)', agent
       end
     end
   end

--- a/spec/acceptance/group/group_local_unicode_group_spec.rb
+++ b/spec/acceptance/group/group_local_unicode_group_spec.rb
@@ -63,13 +63,13 @@ describe 'Group - Unicode' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(prefix, file_content, group_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, powershell(verify_group_command(prefix, raw_group_id), 'EncodedCommand' => true)) do |result|
-            assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{^1$})
           end
         end
       end

--- a/spec/acceptance/group/group_local_unicode_user_spec.rb
+++ b/spec/acceptance/group/group_local_unicode_user_spec.rb
@@ -62,13 +62,13 @@ describe 'Group - Unicode' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(prefix, file_content, group_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, powershell(verify_group_command(prefix, raw_group_id), 'EncodedCommand' => true)) do |result|
-            assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{^1$})
           end
         end
       end

--- a/spec/acceptance/group/group_local_unicode_user_spec.rb
+++ b/spec/acceptance/group/group_local_unicode_user_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper_acceptance'
 
+prefix = SecureRandom.uuid.to_s
+
 describe 'Group - Unicode' do
-  def acl_manifest(prefix, file_content, group_id)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -48,29 +50,17 @@ describe 'Group - Unicode' do
     MANIFEST
   end
 
-  def verify_group_command(prefix, raw_group_id)
-    "(Get-ACL 'c:/temp/#{prefix}.txt' | Where-Object { $_.Group -match ('.*\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) } | Measure-Object).Count"
-  end
+  let(:verify_acl_command) { "(Get-ACL 'c:/temp/#{prefix}.txt' | Where-Object { $_.Group -match ('.*\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) } | Measure-Object).Count" }
+  let(:acl_regex) { %r{^1$} }
 
   context 'Change Group to Local Unicode User' do
-    prefix = SecureRandom.uuid.to_s
-    file_content = 'Burning grass on a cold winter day.'
-    raw_group_id = 'group2_\u03A3\u03A4\u03A5\u03A6'
-    group_id =     "group2_\u03A3\u03A4\u03A5\u03A6" # ΣΤΥΦ
+    let(:file_content) { 'Burning grass on a cold winter day.' }
+    let(:raw_group_id) { 'group2_\u03A3\u03A4\u03A5\u03A6' }
+    let(:group_id) {     "group2_\u03A3\u03A4\u03A5\u03A6" } # ΣΤΥΦ
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(prefix, file_content, group_id), debug: true) do |result|
-            expect(result.stderr).not_to match(%r{Error:})
-          end
-        end
-
-        it 'Verify that ACL Rights are Correct' do
-          on(agent, powershell(verify_group_command(prefix, raw_group_id), 'EncodedCommand' => true)) do |result|
-            expect(result.stdout).to match(%r{^1$})
-          end
-        end
+        include_examples 'execute manifest and verify (with PowerShell)', agent
       end
     end
   end

--- a/spec/acceptance/group/group_local_user_sid_spec.rb
+++ b/spec/acceptance/group/group_local_user_sid_spec.rb
@@ -105,18 +105,19 @@ describe 'Group - SID' do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target, user_id, sid), debug: true) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_group_command) do |result|
-            assert_match(group_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{group_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex, result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex}})
           end
         end
       end

--- a/spec/acceptance/group/group_local_user_sid_spec.rb
+++ b/spec/acceptance/group/group_local_user_sid_spec.rb
@@ -1,124 +1,111 @@
 require 'spec_helper_acceptance'
 
+sid = ''
+
 describe 'Group - SID' do
-  def setup_manifest(target_parent, target, file_content, user_id, group_id)
-    <<-MANIFEST
-      file { "#{target_parent}":
-        ensure => directory
-      }
-
-      file { "#{target}":
-        ensure  => file,
-        content => '#{file_content}',
-        require => File['#{target_parent}']
-      }
-
-      user { "#{user_id}":
-        ensure     => present,
-        groups     => 'Users',
-        managehome => true,
-        password   => "L0v3Pupp3t!"
-      }
-
-      user { "#{group_id}":
-        ensure     => present,
-        groups     => 'Users',
-        managehome => true,
-        password   => "L0v3Pupp3t!"
-      }
-    MANIFEST
-  end
-
-  def acl_manifest(target, user_id, sid)
-    <<-MANIFEST
-        acl { "#{target}":
-          purge           => 'true',
-          permissions     => [
-            { identity    => 'CREATOR GROUP',
-              rights      => ['modify']
-            },
-            { identity    => '#{user_id}',
-              rights      => ['read']
-            },
-            { identity    => 'Administrators',
-              rights      => ['full'],
-              affects     => 'all',
-              child_types => 'all'
-            }
-          ],
-          group           => '#{sid}',
-          inherit_parent_permissions => 'false'
-        }
-    MANIFEST
-  end
-
   context 'Change Group to Local User SID' do
-    os_check_command = 'cmd /c ver'
-    os_check_regex = %r{Version 5}
+    let(:setup_manifest) do
+      <<-MANIFEST
+        file { "#{target_parent}":
+          ensure => directory
+        }
 
-    user_type = 'local_user_sid'
-    file_content = 'Hot eyes in your sand!'
+        file { "#{target}":
+          ensure  => file,
+          content => '#{file_content}',
+          require => File['#{target_parent}']
+        }
 
-    parent_name = 'temp'
-    target_name = "group_#{user_type}.txt"
+        user { "#{user_id}":
+          ensure     => present,
+          groups     => 'Users',
+          managehome => true,
+          password   => "L0v3Pupp3t!"
+        }
 
-    target_parent = "c:/#{parent_name}"
-    target = "#{target_parent}/#{target_name}"
-    user_id = 'bob'
-    group_id = 'tom'
+        user { "#{group_id}":
+          ensure     => present,
+          groups     => 'Users',
+          managehome => true,
+          password   => "L0v3Pupp3t!"
+        }
+      MANIFEST
+    end
 
-    get_group_sid_command = <<-GETSID
-    cmd /c "wmic useraccount where name='#{group_id}' get sid"
-    GETSID
+    let(:acl_manifest) do
+      <<-MANIFEST
+          acl { "#{target}":
+            purge           => 'true',
+            permissions     => [
+              { identity    => 'CREATOR GROUP',
+                rights      => ['modify']
+              },
+              { identity    => '#{user_id}',
+                rights      => ['read']
+              },
+              { identity    => 'Administrators',
+                rights      => ['full'],
+                affects     => 'all',
+                child_types => 'all'
+              }
+            ],
+            group           => '#{sid}',
+            inherit_parent_permissions => 'false'
+          }
+      MANIFEST
+    end
 
-    sid_regex = %r{^(S-.+)$}
+    let(:user_type) { 'local_user_sid' }
+    let(:file_content) { 'Hot eyes in your sand!' }
 
-    verify_content_command = "cat /cygdrive/c/#{parent_name}/#{target_name}"
-    file_content_regex = %r{\A#{file_content}\z}
+    let(:target_name) { "group_#{user_type}.txt" }
 
-    verify_group_command = "icacls #{target}"
-    group_regex = %r{.*\\tom:\(M\)}
-    sid = ''
+    let(:target) { "#{target_parent}/#{target_name}" }
+    let(:user_id) { 'bob' }
+    let(:group_id) { 'tom' }
+
+    let(:get_group_sid_command) do
+      <<-CMD
+        cmd /c "wmic useraccount where name='#{group_id}' get sid"
+      CMD
+    end
+
+    let(:sid_regex) { %r{^(S-.+)$} }
+
+    let(:verify_content_path) { "#{target_parent}/#{target_name}" }
+
+    let(:verify_group_command) { "icacls #{target}" }
+    let(:group_regex) { %r{.*\\tom:\(M\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Determine OS Type' do
-          on(agent, os_check_command) do |result|
-            if os_check_regex =~ result.stdout
-              skip_test('This test cannot run on a Windows 2003 system!')
-            end
+        it 'applies setup manifest' do
+          execute_manifest_on(agent, setup_manifest, debug: true) do |result|
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Execute Setup Manifest' do
-          execute_manifest_on(agent, setup_manifest(target_parent, target, file_content, user_id, group_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
-          end
-        end
-
-        it 'Get SID of User Account' do
+        it 'retrieves SID of user account' do
           on(agent, get_group_sid_command) do |result|
             sid = sid_regex.match(result.stdout)[1]
           end
         end
 
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, user_id, sid), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        it 'applies ACL manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_group_command) do |result|
             expect(result.stdout).to match(%r{#{group_regex}})
           end
         end
 
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex}})
-          end
+        it 'verifies file data integrity' do
+          expect(file(verify_content_path)).to be_file
+          expect(file(verify_content_path).content).to match(%r{#{file_content}})
         end
       end
     end

--- a/spec/acceptance/group/negative/group_257_char_name_spec.rb
+++ b/spec/acceptance/group/negative/group_257_char_name_spec.rb
@@ -57,12 +57,12 @@ describe 'Group - Negative' do
     context "On Windows Agent Change Group to Local Group with Long Name on #{agent}" do
       it 'Attempt to Execute ACL Manifest' do
         execute_manifest_on(agent, acl_manifest, debug: true) do |result|
-          assert_match(expected_error, result.stderr, 'Expected error was not detected!')
+          expect(result.stderr).to match(%r{#{expected_error}})
         end
 
         step 'Verify File Data Integrity'
         on(agent, verify_content_command) do |result|
-          assert_match(file_content_regex, result.stdout, 'File content is invalid!')
+          expect(result.stdout).to match(%r{#{file_content_regex}})
         end
       end
     end

--- a/spec/acceptance/identity/negative/specify_identity_spec.rb
+++ b/spec/acceptance/identity/negative/specify_identity_spec.rb
@@ -34,13 +34,13 @@ describe 'Identity - Negative' do
       context "on #{agent}" do
         it 'Execute Manifest' do
           execute_manifest_on(agent, acl_manifest(target_file, file_content, group_id), debug: true) do |result|
-            assert_match(%r{Error: Failed to set permissions for }, result.stderr, 'Expected error was not detected!')
+            expect(result.stderr).to match(%r{Error: Failed to set permissions for })
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command(target_file)) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end
@@ -56,13 +56,13 @@ describe 'Identity - Negative' do
       context "on #{agent}" do
         it 'Execute Manifest' do
           execute_manifest_on(agent, acl_manifest(target_file, file_content, user_id), debug: true) do |result|
-            assert_match(%r{Error: Failed to set permissions for 'user_not_here'}, result.stderr, 'Expected error was not detected!')
+            expect(result.stderr).to match(%r{Error: Failed to set permissions for 'user_not_here'})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command(target_file)) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/identity/specify_app_package_authority_idents_spec.rb
+++ b/spec/acceptance/identity/specify_app_package_authority_idents_spec.rb
@@ -46,7 +46,7 @@ describe 'Identity' do
             it 'Execute ACL Manifest' do
               # exit code 2: The run succeeded, and some resources were changed.
               execute_manifest_on(agent, acl_manifest, expect_changes: true) do |result|
-                assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+                expect(result.stderr).not_to match(%r{Error:})
               end
             end
 
@@ -54,20 +54,20 @@ describe 'Identity' do
             it 'Verify that ACL Rights are Correct' do
               on(agent, verify_acl_command) do |result|
                 original_acl_rights = result.stdout
-                assert_match(account[:acl_regex], original_acl_rights, 'Expected ACL was not present!')
+                expect(original_acl_rights).to match(%r{#{account[:acl_regex]}})
               end
             end
 
             it 'Execute ACL Manifest again' do
               execute_manifest_on(agent, acl_manifest, catch_changes: true) do |result|
-                assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+                expect(result.stderr).to match(%r{Error:})
               end
             end
 
             it 'Verify that ACL Rights are Correct again' do
               on(agent, verify_acl_command) do |result|
-                assert_match(account[:acl_regex], result.stdout, 'Expected ACL was not present!')
-                assert_equal(result.stdout, original_acl_rights)
+                expect(result.stdout).to match(%r{account[:acl_regex]})
+                expect(result.stdout).to eq(original_acl_rights)
               end
             end
           end

--- a/spec/acceptance/identity/specify_app_package_authority_idents_spec.rb
+++ b/spec/acceptance/identity/specify_app_package_authority_idents_spec.rb
@@ -43,7 +43,7 @@ describe 'Identity' do
               }
             MANIFEST
 
-            it 'Execute ACL Manifest' do
+            it 'applies manifest' do
               # exit code 2: The run succeeded, and some resources were changed.
               execute_manifest_on(agent, acl_manifest, expect_changes: true) do |result|
                 expect(result.stderr).not_to match(%r{Error:})
@@ -51,22 +51,22 @@ describe 'Identity' do
             end
 
             original_acl_rights = ''
-            it 'Verify that ACL Rights are Correct' do
+            it 'verifies ACL rights' do
               on(agent, verify_acl_command) do |result|
                 original_acl_rights = result.stdout
                 expect(original_acl_rights).to match(%r{#{account[:acl_regex]}})
               end
             end
 
-            it 'Execute ACL Manifest again' do
+            it 'applies manifest again, raises error' do
               execute_manifest_on(agent, acl_manifest, catch_changes: true) do |result|
                 expect(result.stderr).to match(%r{Error:})
               end
             end
 
-            it 'Verify that ACL Rights are Correct again' do
+            it 'verifies ACL rights again' do
               on(agent, verify_acl_command) do |result|
-                expect(result.stdout).to match(%r{account[:acl_regex]})
+                expect(result.stdout).to match(%r{#{account[:acl_regex]}})
                 expect(result.stdout).to eq(original_acl_rights)
               end
             end

--- a/spec/acceptance/identity/specify_group_identity_spec.rb
+++ b/spec/acceptance/identity/specify_group_identity_spec.rb
@@ -5,19 +5,19 @@ def apply_manifest_and_verify(agent, file_content, group_id, target_file)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest_with_group(target_file, file_content, group_id), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(target_file)) do |result|
-        assert_match(acl_regex(group_id), result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex(group_id)}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(target_file)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/identity/specify_sid_identity_spec.rb
+++ b/spec/acceptance/identity/specify_sid_identity_spec.rb
@@ -60,7 +60,7 @@ describe 'Module - Identity' do
 
         it 'Execute Setup Manifest' do
           execute_manifest_on(agent, setup_manifest(target_file, file_content), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
@@ -72,19 +72,19 @@ describe 'Module - Identity' do
 
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target_file, sid), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/identity/specify_sid_identity_spec.rb
+++ b/spec/acceptance/identity/specify_sid_identity_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper_acceptance'
 
+sid = ''
+
 describe 'Module - Identity' do
-  def setup_manifest(target_file, file_content)
+  let(:setup_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -22,7 +24,7 @@ describe 'Module - Identity' do
     MANIFEST
   end
 
-  def acl_manifest(target_file, sid)
+  let(:acl_manifest) do
     <<-MANIFEST
       acl { '#{target_parent}/#{target_file}':
         permissions => [
@@ -33,59 +35,52 @@ describe 'Module - Identity' do
   end
 
   context 'Specify SID Identity' do
-    os_check_command = 'cmd /c ver'
-    os_check_regex = %r{Version 5}
-    target_file = 'specify_sid_ident.txt'
-    file_content = 'Magic unicorn rainbow madness!'
-    verify_content_command = "cat /cygdrive/c/temp/#{target_file}"
-    get_user_sid_command = <<-GETSID
-    cmd /c "wmic useraccount where name='#{user_id}' get sid"
-    GETSID
+    let(:os_check_command) { 'cmd /c ver' }
+    let(:os_check_regex) { %r{Version 5} }
+    let(:target_file) { 'specify_sid_ident.txt' }
 
-    sid_regex = %r{^(S-.+)$}
+    let(:file_content) { 'Magic unicorn rainbow madness!' }
+    let(:verify_content_path) { "#{target_parent}/#{target_file}" }
 
-    verify_acl_command = "icacls #{target_parent}/#{target_file}"
-    acl_regex = %r{.*\\bob:\(F\)}
-    sid = ''
+    let(:get_user_sid_command) do
+      <<-CMD
+        cmd /c "wmic useraccount where name='#{user_id}' get sid"
+      CMD
+    end
+
+    let(:sid_regex) { %r{^(S-.+)$} }
+    let(:verify_acl_command) { "icacls #{target_parent}/#{target_file}" }
+    let(:acl_regex) { %r{.*\\bob:\(F\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Determine OS Type' do
-          on(agent, os_check_command) do |result|
-            if os_check_regex =~ result.stdout
-              skip_test('This test cannot run on a Windows 2003 system!')
-            end
-          end
-        end
-
-        it 'Execute Setup Manifest' do
-          execute_manifest_on(agent, setup_manifest(target_file, file_content), debug: true) do |result|
+        it 'applies setup manifest' do
+          execute_manifest_on(agent, setup_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Get SID of User Account' do
+        it 'retrieves SID of user account' do
           on(agent, get_user_sid_command) do |result|
             sid = sid_regex.match(result.stdout)[1]
           end
         end
 
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(target_file, sid), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).to match(%r{#{acl_regex}})
           end
         end
 
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-          end
+        it 'verifies file data integrity' do
+          expect(file(verify_content_path)).to be_file
+          expect(file(verify_content_path).content).to match(%r{#{file_content}})
         end
       end
     end

--- a/spec/acceptance/identity/specify_unicode_identity_spec.rb
+++ b/spec/acceptance/identity/specify_unicode_identity_spec.rb
@@ -1,22 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(agent, file_content, target, user_id, verify_acl_command)
-  it 'Execute Manifest' do
-    execute_manifest_on(agent, acl_manifest_user(target, file_content, user_id), debug: true) do |result|
-      expect(result.stderr).not_to match(%r{Error:})
-    end
-  end
-
-  it 'Verify that ACL Rights are Correct' do
-    on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-      expect(result.stdout).to match(%r{^1$})
-    end
-  end
-end
-
 describe 'Identity' do
-  def acl_manifest_group(target, file_content, group_id)
+  let(:acl_manifest_group) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -40,7 +25,7 @@ describe 'Identity' do
     MANIFEST
   end
 
-  def acl_manifest_user(target, file_content, user_id)
+  let(:acl_manifest_user) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -67,44 +52,37 @@ describe 'Identity' do
     MANIFEST
   end
 
+  let(:acl_regex) { %r{^1$} }
+
   context 'Specify Group Name Containing Unicode for Identity' do
     prefix = SecureRandom.uuid.to_s
-    target = "c:/temp/#{prefix}.txt"
-    raw_group_id = 'group_\uB81D\uB534\uC2AB\uC788\uCC98'
-    group_id = "group_\uB81D\uB534\uC2AB\uC788\uCC98" # 렝딴슫있처
-    file_content = 'Garbage bag full of money.'
-    verify_acl_command = "(Get-ACL '#{target}' | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match ('\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count" # rubocop:disable Metrics/LineLength
+    let(:acl_manifest) { acl_manifest_group }
+    let(:target) { "#{target_parent}/#{prefix}.txt" }
+    let(:raw_group_id) { 'group_\uB81D\uB534\uC2AB\uC788\uCC98' }
+    let(:group_id) { "group_\uB81D\uB534\uC2AB\uC788\uCC98" } # 렝딴슫있처
+    let(:file_content) { 'Garbage bag full of money.' }
+    let(:verify_acl_command) { "(Get-ACL '#{target}' | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match ('\\\\' + [regex]::Unescape(\"#{raw_group_id}\")) -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count" } # rubocop:disable Metrics/LineLength
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute Manifest' do
-          execute_manifest_on(agent, acl_manifest_group(target, file_content, group_id), debug: true) do |result|
-            expect(result.stderr).not_to match(%r{Error:})
-          end
-        end
-
-        it 'Verify that ACL Rights are Correct' do
-          on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-            expect(result.stdout).not_to match(%r{^1$})
-          end
-        end
+        include_examples 'execute manifest and verify (with PowerShell)', agent
       end
     end
   end
 
   context 'Windows ACL Module - Specify User Name Containing Unicode for Identity' do
     prefix = SecureRandom.uuid.to_s
-    target = "c:/temp/#{prefix}.txt"
-    raw_user_id = 'user_\uB81D\uB534\uC2AB\uC788\uCC98'
-    user_id = "user_\uB81D\uB534\uC2AB\uC788\uCC98" # 렝딴슫있처
-    file_content = 'Flying Spaghetti Monster wants to save your soul.'
-    verify_acl_command = "(Get-ACL '#{target}' | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match ('\\\\' + [regex]::Unescape(\"#{raw_user_id}\")) -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count" # rubocop:disable Metrics/LineLength
+    let(:acl_manifest) { acl_manifest_user }
+    let(:target) { "#{target_parent}/#{prefix}.txt" }
+    let(:raw_user_id) { 'user_\uB81D\uB534\uC2AB\uC788\uCC98' }
+    let(:user_id) { "user_\uB81D\uB534\uC2AB\uC788\uCC98" } # 렝딴슫있처
+    let(:file_content) { 'Flying Spaghetti Monster wants to save your soul.' }
+    let(:verify_acl_command) { "(Get-ACL '#{target}' | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match ('\\\\' + [regex]::Unescape(\"#{raw_user_id}\")) -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count" } # rubocop:disable Metrics/LineLength
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        apply_manifest_and_verify(agent, file_content, target, user_id, verify_acl_command)
+        include_examples 'execute manifest and verify (with PowerShell)', agent
       end
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/identity/specify_unicode_identity_spec.rb
+++ b/spec/acceptance/identity/specify_unicode_identity_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper_acceptance'
 def apply_manifest_and_verify(agent, file_content, target, user_id, verify_acl_command)
   it 'Execute Manifest' do
     execute_manifest_on(agent, acl_manifest_user(target, file_content, user_id), debug: true) do |result|
-      assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+      expect(result.stderr).not_to match(%r{Error:})
     end
   end
 
   it 'Verify that ACL Rights are Correct' do
     on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-      assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+      expect(result.stdout).to match(%r{^1$})
     end
   end
 end
@@ -79,13 +79,13 @@ describe 'Identity' do
       context "on #{agent}" do
         it 'Execute Manifest' do
           execute_manifest_on(agent, acl_manifest_group(target, file_content, group_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-            assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).not_to match(%r{^1$})
           end
         end
       end

--- a/spec/acceptance/identity/specify_user_identity_spec.rb
+++ b/spec/acceptance/identity/specify_user_identity_spec.rb
@@ -1,29 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(agent, file_content, user_id, target_file)
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(file_content, user_id, target_file), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command(target_file)) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex(user_id)}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command(target_file)) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Identity - User' do
-  def acl_manifest(file_content, user_id, target_file)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -50,26 +28,18 @@ describe 'Identity - User' do
     MANIFEST
   end
 
-  def verify_content_command(target_file)
-    "cat /cygdrive/c/temp/#{target_file}"
-  end
+  let(:verify_acl_command) { "icacls #{target_parent}/#{target_file}" }
 
-  def verify_acl_command(target_file)
-    "icacls #{target_parent}/#{target_file}"
-  end
-
-  def acl_regex(user_id)
-    %r{.*\\#{user_id}:\(F\)}
-  end
+  let(:verify_content_path) { "#{target_parent}/#{target_file}" }
 
   context 'Specify User with Long Name for Identity' do
-    target_file = 'specify_long_user_ident.txt'
-    user_id = 'user_very_long_name1'
-    file_content = 'Brown cow goes moo.'
+    let(:target_file) { 'specify_long_user_ident.txt' }
+    let(:user_id) { 'user_very_long_name1' }
+    let(:file_content) { 'Brown cow goes moo.' }
+    let(:acl_regex) { %r{.*\\#{user_id}:\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, file_content, user_id, target_file)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/identity/specify_user_identity_spec.rb
+++ b/spec/acceptance/identity/specify_user_identity_spec.rb
@@ -5,18 +5,18 @@ def apply_manifest_and_verify(agent, file_content, user_id, target_file)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(file_content, user_id, target_file), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command(target_file)) do |result|
-        assert_match(acl_regex(user_id), result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex(user_id)}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(target_file)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/inheritance/inheritance_on_dir_spec.rb
+++ b/spec/acceptance/inheritance/inheritance_on_dir_spec.rb
@@ -11,13 +11,13 @@ def apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_chi
   context "on #{agent}" do
     it 'Execute Apply Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, target_child, user_id_child, rights, perm_type, child_inherit_type), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct on Child' do
       on(agent, verify_child_acl_command(target_child)) do |result|
-        assert_match(acl_child_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_child_regex}})
       end
     end
   end

--- a/spec/acceptance/inheritance/inheritance_on_dir_spec.rb
+++ b/spec/acceptance/inheritance/inheritance_on_dir_spec.rb
@@ -1,30 +1,13 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, agent)
-  rights = 'full'
-  user_id_child = 'roberto'
-  target_name = "inherit_#{perm_type}_on_#{asset_type}"
-  target_child_name = "child_#{asset_type}"
-  target_child = "#{target_parent}/#{target_name}/#{target_child_name}"
-
-  context "on #{agent}" do
-    it 'Execute Apply Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, target_child, user_id_child, rights, perm_type, child_inherit_type), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct on Child' do
-      on(agent, verify_child_acl_command(target_child)) do |result|
-        expect(result.stdout).to match(%r{#{acl_child_regex}})
-      end
-    end
-  end
-end
-
 describe 'Inheritance - Directory' do
-  def acl_manifest(target_name, target_child, user_id_child, rights, perm_type, child_inherit_type)
+  let(:rights) { 'full' }
+  let(:user_id_child) { 'roberto' }
+  let(:target_name) { "inherit_#{perm_type}_on_#{asset_type}" }
+  let(:target_child_name) { "child_#{asset_type}" }
+  let(:target_child) { "#{target_parent}/#{target_name}/#{target_child_name}" }
+
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -80,52 +63,50 @@ describe 'Inheritance - Directory' do
     MANIFEST
   end
 
-  def verify_child_acl_command(target_child)
-    "icacls #{target_child}"
-  end
+  let(:verify_acl_command) { "icacls #{target_child}" }
+  let(:verify_content_path) { "#{target_parent}/#{target_name}" }
 
   context 'Explicit Inheritance of "allow" Parent Permissions for Directory' do
-    perm_type = 'allow'
-    asset_type = 'dir'
-    child_inherit_type = 'true'
-    acl_child_regex = %r{.*\\bob:\(I\)\(OI\)\(CI\)\(F\)}
+    let(:perm_type) { 'allow' }
+    let(:asset_type) { 'dir' }
+    let(:child_inherit_type) { 'true' }
+    let(:acl_regex) { %r{.*\\bob:\(I\)\(OI\)\(CI\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Explicit Inheritance of "deny" Parent Permissions for Directory' do
-    perm_type = 'deny'
-    asset_type = 'dir'
-    child_inherit_type = 'true'
-    acl_child_regex = %r{.*\\bob:\(I\)\(OI\)\(CI\)\(N\)}
+    let(:perm_type) { 'deny' }
+    let(:asset_type) { 'dir' }
+    let(:child_inherit_type) { 'true' }
+    let(:acl_regex) { %r{.*\\bob:\(I\)\(OI\)\(CI\)\(N\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Remove Inheritance of "allow" Parent Permissions for Directory' do
-    perm_type = 'allow'
-    asset_type = 'dir'
-    child_inherit_type = 'false'
-    acl_child_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
+    let(:perm_type) { 'allow' }
+    let(:asset_type) { 'dir' }
+    let(:child_inherit_type) { 'false' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Remove Inheritance of "deny" Parent Permissions for Directory' do
-    perm_type = 'deny'
-    asset_type = 'dir'
-    child_inherit_type = 'false'
-    acl_child_regex = %r{.*\\bob:\(OI\)\(CI\)\(N\)}
+    let(:perm_type) { 'deny' }
+    let(:asset_type) { 'dir' }
+    let(:child_inherit_type) { 'false' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(N\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/inheritance/inheritance_on_file_spec.rb
+++ b/spec/acceptance/inheritance/inheritance_on_file_spec.rb
@@ -1,36 +1,13 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, file_content, agent)
-  rights = 'full'
-  user_id_child = 'roberto'
-  target_name = "inherit_#{perm_type}_on_#{asset_type}"
-  target_child_name = "child_#{asset_type}"
-  target_child = "#{target_parent}/#{target_name}/#{target_child_name}"
-
-  context "on #{agent}" do
-    it 'Execute Apply Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, target_child, file_content, user_id_child, rights, perm_type, child_inherit_type), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct on Child' do
-      on(agent, verify_child_acl_command(target_child)) do |result|
-        expect(result.stdout).to match(%r{#{acl_child_regex}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command(target_name, target_child_name)) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Inheritance' do
-  def acl_manifest(target_name, target_child, file_content, user_id_child, rights, perm_type, child_inherit_type)
+  let(:rights) { 'full' }
+  let(:user_id_child) { 'roberto' }
+  let(:target_name) { "inherit_#{perm_type}_on_#{asset_type}" }
+  let(:target_child_name) { "child_#{asset_type}" }
+  let(:target_child) { "#{target_parent}/#{target_name}/#{target_child_name}" }
+
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -87,60 +64,54 @@ describe 'Inheritance' do
     MANIFEST
   end
 
-  def verify_child_acl_command(target_child)
-    "icacls #{target_child}"
-  end
-
-  def verify_content_command(target_name, target_child_name)
-    "cat /cygdrive/c/temp/#{target_name}/#{target_child_name}"
-  end
+  let(:verify_acl_command) { "icacls #{target_child}" }
+  let(:verify_content_path) { "c:\\temp\\#{target_name}\\#{target_child_name}" }
 
   context 'Explicit Inheritance of "allow" Parent Permissions for File' do
-    perm_type = 'allow'
-    asset_type = 'file'
-    child_inherit_type = 'true'
-    file_content = 'Car repair is expensive'
-    acl_child_regex = %r{.*\\bob:\(I\)\(F\)}
+    let(:perm_type) { 'allow' }
+    let(:asset_type) { 'file' }
+    let(:child_inherit_type) { 'true' }
+    let(:file_content) { 'Car repair is expensive' }
+    let(:acl_regex) { %r{.*\\bob:\(I\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, file_content, agent)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Explicit Inheritance of "deny" Parent Permissions for File' do
-    perm_type = 'deny'
-    asset_type = 'file'
-    child_inherit_type = 'true'
-    file_content = 'Exploding pants on sale for half off.'
-    acl_child_regex = %r{.*\\bob:\(I\)\(N\)}
+    let(:perm_type) { 'deny' }
+    let(:asset_type) { 'file' }
+    let(:child_inherit_type) { 'true' }
+    let(:file_content) { 'Exploding pants on sale for half off.' }
+    let(:acl_regex) { %r{.*\\bob:\(I\)\(N\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, file_content, agent)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Remove Inheritance of "allow" Parent Permissions for File' do
-    perm_type = 'allow'
-    asset_type = 'file'
-    child_inherit_type = 'false'
-    file_content = 'Smell-o-vision: brought to you by the makers of Taste-o-vision!'
-    acl_child_regex = %r{.*\\bob:\(F\)}
+    let(:perm_type) { 'allow' }
+    let(:asset_type) { 'file' }
+    let(:child_inherit_type) { 'false' }
+    let(:file_content) { 'Smell-o-vision: brought to you by the makers of Taste-o-vision!' }
+    let(:acl_regex) { %r{.*\\bob:\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, file_content, agent)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Remove Inheritance of "deny" Parent Permissions for File' do
-    perm_type = 'deny'
-    asset_type = 'file'
-    child_inherit_type = 'false'
-    file_content = 'She smirked as he disdainfully choked down her tasteless humor.'
-    acl_child_regex = %r{.*\\bob:\(N\)}
+    let(:perm_type) { 'deny' }
+    let(:asset_type) { 'file' }
+    let(:child_inherit_type) { 'false' }
+    let(:file_content) { 'She smirked as he disdainfully choked down her tasteless humor.' }
+    let(:acl_regex) { %r{.*\\bob:\(N\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_child_regex, file_content, agent)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/inheritance/inheritance_on_file_spec.rb
+++ b/spec/acceptance/inheritance/inheritance_on_file_spec.rb
@@ -11,19 +11,19 @@ def apply_manifest_and_verify(perm_type, asset_type, child_inherit_type, acl_chi
   context "on #{agent}" do
     it 'Execute Apply Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, target_child, file_content, user_id_child, rights, perm_type, child_inherit_type), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct on Child' do
       on(agent, verify_child_acl_command(target_child)) do |result|
-        assert_match(acl_child_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_child_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command(target_name, target_child_name)) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/owner/negative/owner_257_char_name_spec.rb
+++ b/spec/acceptance/owner/negative/owner_257_char_name_spec.rb
@@ -1,27 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(agent, target_name, file_content, user_id, owner_id)
-  context "on #{agent}" do
-    expected_error = %r{Error:.*User does not exist}
-    verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
-
-    it 'Attempt to Execute ACL Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, file_content, user_id, owner_id), debug: true) do |result|
-        expect(result.stderr).to match(%r{#{expected_error}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Owner - Negative' do
-  def acl_manifest(target_name, file_content, user_id, owner_id)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -51,14 +31,24 @@ describe 'Owner - Negative' do
     MANIFEST
   end
 
+  let(:verify_content_path) { "#{target_parent}/#{target_name}" }
+
   context 'Specify 257 Character String for Owner' do
-    file_content = 'I AM TALKING VERY LOUD!'
-    target_name = 'owner_257_char_name.txt'
-    owner_id = 'jasqddsweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg' # rubocop:disable Metrics/LineLength
+    let(:file_content) { 'I AM TALKING VERY LOUD!' }
+    let(:target_name) { 'owner_257_char_name.txt' }
+    let(:owner_id) { 'jasqddsweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg' } # rubocop:disable Metrics/LineLength
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target_name, file_content, user_id, owner_id)
+      it 'applies manifest, raises error' do
+        execute_manifest_on(agent, acl_manifest, debug: true) do |result|
+          expect(result.stderr).to match(%r{Error:.*User does not exist})
+        end
+      end
+
+      it 'verifies file data integrity' do
+        expect(file(verify_content_path)).to be_file
+        expect(file(verify_content_path).content).to match(%r{#{file_content}})
+      end
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/owner/negative/owner_257_char_name_spec.rb
+++ b/spec/acceptance/owner/negative/owner_257_char_name_spec.rb
@@ -8,13 +8,13 @@ def apply_manifest_and_verify(agent, target_name, file_content, user_id, owner_i
 
     it 'Attempt to Execute ACL Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, file_content, user_id, owner_id), debug: true) do |result|
-        assert_match(expected_error, result.stderr, 'Expected error was not detected!')
+        expect(result.stderr).to match(%r{#{expected_error}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/owner/owner_local_group_spec.rb
+++ b/spec/acceptance/owner/owner_local_group_spec.rb
@@ -9,19 +9,19 @@ def apply_manifest_and_verify(agent, target_name, file_content, owner_id, owner_
 
     it 'Execute ACL Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_owner_command) do |result|
-        assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{owner_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end
@@ -96,13 +96,13 @@ describe 'Owner - Local Group' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, powershell(verify_owner_command, 'EncodedCommand' => true)) do |result|
-            assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{^1$})
           end
         end
       end

--- a/spec/acceptance/owner/owner_local_group_spec.rb
+++ b/spec/acceptance/owner/owner_local_group_spec.rb
@@ -1,34 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup
-def apply_manifest_and_verify(agent, target_name, file_content, owner_id, owner_regex)
-  context "on #{agent}" do
-    verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
-    dosify_target = "c:\\temp\\#{target_name}"
-    verify_owner_command = "cmd /c \"dir /q #{dosify_target}\""
-
-    it 'Execute ACL Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_owner_command) do |result|
-        expect(result.stdout).to match(%r{#{owner_regex}})
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Owner - Local Group' do
-  def acl_manifest(target_name, file_content, owner_id)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -62,51 +35,45 @@ describe 'Owner - Local Group' do
     MANIFEST
   end
 
+  let(:dosify_target) { "c:\\temp\\#{target_name}" }
+  let(:verify_acl_command) { "cmd /c \"dir /q #{dosify_target}\"" }
+  let(:verify_content_path) { "#{target_parent}/#{target_name}" }
+
   context 'Change Owner to Local Group' do
-    file_content = 'Spearhead was a great MOHAA game.'
-    target_name = 'owner_local_group.txt'
-    owner_id = 'jerks'
-    owner_regex = %r{.*\\jerks}
+    let(:file_content) { 'Spearhead was a great MOHAA game.' }
+    let(:target_name) { 'owner_local_group.txt' }
+    let(:owner_id) { 'jerks' }
+    let(:acl_regex) { %r{.*\\jerks} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target_name, file_content, owner_id, owner_regex)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Change Owner to Local Group with Long Name' do
-    file_content = 'Cow are animals with mooing capabilities.'
-    target_name = 'owner_local_long_group_name.txt'
-    owner_id = 'jasqddweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg' # rubocop:disable Metrics/LineLength
-    owner_regex = %r{.*\\jasq}
+    let(:file_content) { 'Cow are animals with mooing capabilities.' }
+    let(:target_name) { 'owner_local_long_group_name.txt' }
+    let(:owner_id) { 'jasqddweruwqiouroaysfyuasudyfaisoyfqoiuwyefiaysdiyfzixycivzixyvciqywifyiasdiufyasdygfasirfwerqiuwyeriatsdtfastdfqwyitfastdfawerfytasdytfasydgtaisdytfiasydfiosayghiayhidfhygiasftawyegyfhgaysgfuyasgdyugfasuiyfguaqyfgausydgfaywgfuasgdfuaisydgfausasdfuygsadfyg' } # rubocop:disable Metrics/LineLength
+    let(:acl_regex) { %r{.*\\jasq} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target_name, file_content, owner_id, owner_regex)
+      include_examples 'execute manifest and verify file', agent
     end
   end
 
   context 'Change Owner to Local Unicode Group' do
-    file_content = 'I thought things on a Saturday night.'
     prefix = SecureRandom.uuid.to_s
-    target_name = "#{prefix}.txt"
-    raw_owner_id = '\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE'
-    owner_id =     "\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE" # 䎈含㴼罍率䎁叴秀㪲軞
-    verify_owner_command = "(Get-ACL '#{target_parent}/#{target_name}' | Where-Object { $_.Owner -match ('.*\\\\' + [regex]::Unescape(\"#{raw_owner_id}\")) } | Measure-Object).Count"
+    let(:file_content) { 'I thought things on a Saturday night.' }
+    let(:target_name) { "#{prefix}.txt" }
+    let(:raw_owner_id) { '\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE' }
+    let(:owner_id) { "\u4388\u542B\u3D3C\u7F4D\uF961\u4381\u53F4\u79C0\u3AB2\u8EDE" } # 䎈含㴼罍率䎁叴秀㪲軞
+    let(:verify_acl_command) { "(Get-ACL '#{target_parent}/#{target_name}' | Where-Object { $_.Owner -match ('.*\\\\' + [regex]::Unescape(\"#{raw_owner_id}\")) } | Measure-Object).Count" }
+    let(:acl_regex) { %r{^1$} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
-            expect(result.stderr).not_to match(%r{Error:})
-          end
-        end
-
-        it 'Verify that ACL Rights are Correct' do
-          on(agent, powershell(verify_owner_command, 'EncodedCommand' => true)) do |result|
-            expect(result.stdout).to match(%r{^1$})
-          end
-        end
+        include_examples 'execute manifest and verify (with PowerShell)', agent
       end
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/owner/owner_local_user_sid_spec.rb
+++ b/spec/acceptance/owner/owner_local_user_sid_spec.rb
@@ -75,7 +75,7 @@ describe 'Owner - SID' do
 
         it 'Execute Setup Manifest' do
           execute_manifest_on(agent, setup_manifest(target_name, file_content, owner_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
@@ -87,19 +87,19 @@ describe 'Owner - SID' do
 
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target_name, sid), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_owner_command) do |result|
-            assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{owner_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex, result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex}})
           end
         end
       end

--- a/spec/acceptance/owner/owner_local_user_spec.rb
+++ b/spec/acceptance/owner/owner_local_user_spec.rb
@@ -9,19 +9,19 @@ def apply_manifest_and_verify(agent, file_content, owner_id, target_name, owner_
 
     it 'Execute ACL Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_owner_command) do |result|
-        assert_match(owner_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{owner_regex}})
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end
@@ -100,13 +100,13 @@ describe 'Owner - Local User' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target_name, file_content, owner_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, powershell(verify_owner_command, 'EncodedCommand' => true)) do |result|
-            assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+            expect(result.stderr).not_to match(%r{^1$})
           end
         end
       end

--- a/spec/acceptance/parameter_target/explicit_target_spec.rb
+++ b/spec/acceptance/parameter_target/explicit_target_spec.rb
@@ -34,13 +34,13 @@ describe 'Windows ACL Module - Explicit Use of "target" Parameter' do
     context "on #{agent}" do
       it 'Execute Manifest' do
         execute_manifest_on(agent, acl_manifest, debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{acl_regex}})
         end
       end
     end

--- a/spec/acceptance/parameter_target/explicit_target_spec.rb
+++ b/spec/acceptance/parameter_target/explicit_target_spec.rb
@@ -1,48 +1,40 @@
 require 'spec_helper_acceptance'
 
 describe 'Windows ACL Module - Explicit Use of "target" Parameter' do
-  target = 'c:/temp/explicit_target'
-  verify_acl_command = "icacls #{target}"
-  acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
+  let(:target) { 'c:/temp/explicit_target' }
+  let(:verify_acl_command) { "icacls #{target}" }
+  let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(F\)} }
 
-  acl_manifest = <<-MANIFEST
-    file { '#{target_parent}':
-      ensure => directory
-    }
+  let(:acl_manifest) do
+    <<-MANIFEST
+      file { '#{target_parent}':
+        ensure => directory
+      }
 
-    file { '#{target}':
-      ensure  => directory,
-      require => File['#{target_parent}']
-    }
+      file { '#{target}':
+        ensure  => directory,
+        require => File['#{target_parent}']
+      }
 
-    user { '#{user_id}':
-      ensure     => present,
-      groups     => 'Users',
-      managehome => true,
-      password   => "L0v3Pupp3t!"
-    }
+      user { '#{user_id}':
+        ensure     => present,
+        groups     => 'Users',
+        managehome => true,
+        password   => "L0v3Pupp3t!"
+      }
 
-    acl { 'explicit_target':
-      target => '#{target}',
-      permissions => [
-        { identity => '#{user_id}', rights => ['full'] },
-      ],
-    }
+      acl { 'explicit_target':
+        target => '#{target}',
+        permissions => [
+          { identity => '#{user_id}', rights => ['full'] },
+        ],
+      }
     MANIFEST
+  end
 
   windows_agents.each do |agent|
     context "on #{agent}" do
-      it 'Execute Manifest' do
-        execute_manifest_on(agent, acl_manifest, debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
-        end
-      end
-
-      it 'Verify that ACL Rights are Correct' do
-        on(agent, verify_acl_command) do |result|
-          expect(result.stdout).to match(%r{#{acl_regex}})
-        end
-      end
+      include_examples 'execute manifest', agent
     end
   end
 end

--- a/spec/acceptance/parameter_target/negative/negative_acl_spec.rb
+++ b/spec/acceptance/parameter_target/negative/negative_acl_spec.rb
@@ -27,7 +27,7 @@ describe 'Parameter Target - Negative' do
       target = ''
       it 'Execute Manifest' do
         execute_manifest_on(agent, acl_manifest(target), debug: true, exepect_failures: true) do |result|
-          assert_match(%r{Error:.*(A non-empty name must be specified|Empty string title at)}, result.stderr, 'Expected error was not detected!')
+          expect(result.stderr).to match(%r{Error:.*(A non-empty name must be specified|Empty string title at)})
         end
       end
     end
@@ -38,8 +38,7 @@ describe 'Parameter Target - Negative' do
       target = 'c:/temp/invalid_<:>|?*'
       it 'Execute Manifest' do
         execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
-          assert_match(%r{Error:.*The filename, directory name, or volume label syntax is incorrect},
-                       result.stderr, 'Expected error was not detected!')
+          expect(result.stderr).to match(%r{Error:.*The filename, directory name, or volume label syntax is incorrect})
         end
       end
     end

--- a/spec/acceptance/parameter_target/negative/negative_acl_spec.rb
+++ b/spec/acceptance/parameter_target/negative/negative_acl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Parameter Target - Negative' do
-  def acl_manifest(target)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -24,9 +24,10 @@ describe 'Parameter Target - Negative' do
 
   windows_agents.each do |agent|
     context "Specify Blank Target on #{agent}" do
-      target = ''
-      it 'Execute Manifest' do
-        execute_manifest_on(agent, acl_manifest(target), debug: true, exepect_failures: true) do |result|
+      let(:target) { '' }
+
+      it 'applies manifest' do
+        execute_manifest_on(agent, acl_manifest, debug: true, exepect_failures: true) do |result|
           expect(result.stderr).to match(%r{Error:.*(A non-empty name must be specified|Empty string title at)})
         end
       end
@@ -35,9 +36,10 @@ describe 'Parameter Target - Negative' do
 
   windows_agents.each do |agent|
     context "Specify Target with Invalid Path Characters on #{agent}" do
-      target = 'c:/temp/invalid_<:>|?*'
-      it 'Execute Manifest' do
-        execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
+      let(:target) { 'c:/temp/invalid_<:>|?*' }
+
+      it 'applies manifest' do
+        execute_manifest_on(agent, acl_manifest, debug: true) do |result|
           expect(result.stderr).to match(%r{Error:.*The filename, directory name, or volume label syntax is incorrect})
         end
       end

--- a/spec/acceptance/parameter_target/negative/negative_acl_to_symlink_spec.rb
+++ b/spec/acceptance/parameter_target/negative/negative_acl_to_symlink_spec.rb
@@ -1,84 +1,75 @@
 require 'spec_helper_acceptance'
 
 describe 'Negative - Specify Symlink as Target' do
-  os_check_command = 'cmd /c ver'
-  os_check_regex = %r{Version 5}
+  let(:os_check_command) { 'cmd /c ver' }
+  let(:os_check_regex) { %r{Version 5} }
 
-  target = 'c:/temp/sym_target_file.txt'
-  target_symlink = 'c:/temp/symlink'
+  let(:target) { 'c:/temp/sym_target_file.txt' }
+  let(:target_symlink) { 'c:/temp/symlink' }
 
-  file_content = 'A link to the past.'
-  verify_content_command = 'cat /cygdrive/c/temp/sym_target_file.txt'
+  let(:file_content) { 'A link to the past.' }
+  let(:verify_content_path) { "#{target_parent}/sym_target_file.txt" }
 
-  win_target = 'c:\\temp\\sym_target_file.txt'
-  win_target_symlink = 'c:\\temp\\symlink'
-  mklink_command = "c:\\windows\\system32\\cmd.exe /c mklink #{win_target_symlink} #{win_target}"
+  let(:win_target) { 'c:\\temp\\sym_target_file.txt' }
+  let(:win_target_symlink) { 'c:\\temp\\symlink' }
+  let(:mklink_command) { "c:\\windows\\system32\\cmd.exe /c mklink #{win_target_symlink} #{win_target}" }
 
-  verify_acl_command = "icacls #{target_symlink}"
-  acl_regex = %r{.*\\bob:\(F\)}
+  let(:verify_acl_command) { "icacls #{target_symlink}" }
+  let(:acl_regex) { %r{.*\\bob:\(F\)} }
 
-  acl_manifest = <<-MANIFEST
-    file { "#{target_parent}":
-      ensure => directory
-    }
+  let(:acl_manifest) do
+    <<-MANIFEST
+      file { "#{target_parent}":
+        ensure => directory
+      }
 
-    file { '#{target}':
-      ensure  => file,
-      content => '#{file_content}',
-      require => File['#{target_parent}']
-    }
+      file { '#{target}':
+        ensure  => file,
+        content => '#{file_content}',
+        require => File['#{target_parent}']
+      }
 
-    user { "#{user_id}":
-      ensure     => present,
-      groups     => 'Users',
-      managehome => true,
-      password   => "L0v3Pupp3t!",
-      require => File['#{target}']
-    }
+      user { "#{user_id}":
+        ensure     => present,
+        groups     => 'Users',
+        managehome => true,
+        password   => "L0v3Pupp3t!",
+        require => File['#{target}']
+      }
 
-    exec { 'Create Windows Symlink':
-      command => '#{mklink_command}',
-      creates => '#{target_symlink}',
-      cwd     => '#{target_parent}',
-      require => User['#{user_id}']
-    }
+      exec { 'Create Windows Symlink':
+        command => '#{mklink_command}',
+        creates => '#{target_symlink}',
+        cwd     => '#{target_parent}',
+        require => User['#{user_id}']
+      }
 
-    acl { "#{target_symlink}":
-      permissions  => [
-        { identity => '#{user_id}', rights => ['full'] },
-      ],
-      require      => Exec['Create Windows Symlink']
-    }
-  MANIFEST
+      acl { "#{target_symlink}":
+        permissions  => [
+          { identity => '#{user_id}', rights => ['full'] },
+        ],
+        require      => Exec['Create Windows Symlink']
+      }
+    MANIFEST
+  end
 
   windows_agents.each do |agent|
     context "on #{agent}" do
-      # Determine if running on Windows 2003.
-      # Skip if 2003 since MKLINK is not available.
-      it 'Determine OS Type' do
-        on(agent, os_check_command) do |result|
-          if os_check_regex =~ result.stdout
-            skip_test('This test cannot run on a Windows 2003 system!')
-          end
-        end
-      end
-
-      it 'Execute Manifest' do
+      it 'applies manifest' do
         execute_manifest_on(agent, acl_manifest, debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
+          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
         end
       end
 
-      it 'Verify that ACL Rights are Correct' do
+      it 'verifies ACL rights' do
         on(agent, verify_acl_command) do |result|
-          expect(result.stderr).not_to match(%r{#{acl_regex}})
+          assert_no_match(acl_regex, result.stdout, 'Expected ACL was not present!')
         end
       end
 
-      it 'Verify File Data Integrity' do
-        on(agent, verify_content_command) do |result|
-          expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-        end
+      it 'verifies file data integrity' do
+        expect(file(verify_content_path)).to be_file
+        expect(file(verify_content_path).content).to match(%r{#{file_content}})
       end
     end
   end

--- a/spec/acceptance/parameter_target/negative/negative_acl_to_symlink_spec.rb
+++ b/spec/acceptance/parameter_target/negative/negative_acl_to_symlink_spec.rb
@@ -65,19 +65,19 @@ describe 'Negative - Specify Symlink as Target' do
 
       it 'Execute Manifest' do
         execute_manifest_on(agent, acl_manifest, debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_no_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stderr).not_to match(%r{#{acl_regex}})
         end
       end
 
       it 'Verify File Data Integrity' do
         on(agent, verify_content_command) do |result|
-          assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+          expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
         end
       end
     end

--- a/spec/acceptance/parameter_target/perms_on_dir_8dot3_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_dir_8dot3_spec.rb
@@ -6,25 +6,25 @@ def apply_manifest_and_verify(agent, target, target8dot3, verify_acl_command, re
     acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(target, target8dot3), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
     if remove
       it 'Execute Remove Manifest' do
         execute_manifest_on(agent, acl_manifest_remove(target8dot3), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_no_match(acl_regex, result.stdout, 'Unexpected ACL was present!')
+          expect(result.stdout).not_to match(%r{#{acl_regex}})
         end
       end
     end

--- a/spec/acceptance/parameter_target/perms_on_dir_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_dir_spec.rb
@@ -7,25 +7,25 @@ def apply_manifest_and_verify(agent, target, remove = false)
     acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
     if remove
       it 'Execute Remove Manifest' do
         execute_manifest_on(agent, acl_manifest_remove(target), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_no_match(acl_regex, result.stdout, 'Unexpected ACL was present!')
+          expect(result.stdout).not_to match(%r{#{acl_regex}})
         end
       end
     end
@@ -113,13 +113,13 @@ describe 'Permissions - Directory' do
     windows_agents.each do |agent|
       it 'Execute Manifest' do
         execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-          assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{^1$})
         end
       end
     end

--- a/spec/acceptance/parameter_target/perms_on_dir_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_dir_spec.rb
@@ -1,39 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup, RSpec/RepeatedDescription
-def apply_manifest_and_verify(agent, target, remove = false)
-  context "on #{agent}" do
-    verify_acl_command = "icacls #{target}"
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-    if remove
-      it 'Execute Remove Manifest' do
-        execute_manifest_on(agent, acl_manifest_remove(target), debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
-        end
-      end
-
-      it 'Verify that ACL Rights are Correct' do
-        on(agent, verify_acl_command) do |result|
-          expect(result.stdout).not_to match(%r{#{acl_regex}})
-        end
-      end
-    end
-  end
-end
-
 describe 'Permissions - Directory' do
-  def acl_manifest(target)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -59,7 +27,7 @@ describe 'Permissions - Directory' do
     MANIFEST
   end
 
-  def acl_manifest_remove(target)
+  let(:acl_manifest_remove) do
     <<-MANIFEST
       acl { '#{target}':
         purge => 'listed_permissions',
@@ -70,59 +38,51 @@ describe 'Permissions - Directory' do
     MANIFEST
   end
 
+  let(:verify_acl_command) { "icacls #{target}" }
+  let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(F\)} }
+
   context 'Add Permissions to a Directory with a Long Name (247 chars)' do
-    target = 'c:/temp/ybqYlVTjWTRAaQPPyeaseAsuUhnclarfedIpqIdqwyimqPphcKpojhTHogTUWiaEkiOqbeEZKvNAqDcEjJarQzeNxihARGLytPNseasKZxhRxeCwZsopSUFTKTAgsxsBqRigMlZhFQiELGLZghRwhKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSChEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrPhasdEfU' # rubocop:disable Metrics/LineLength
+    let(:target) { 'c:/temp/ybqYlVTjWTRAaQPPyeaseAsuUhnclarfedIpqIdqwyimqPphcKpojhTHogTUWiaEkiOqbeEZKvNAqDcEjJarQzeNxihARGLytPNseasKZxhRxeCwZsopSUFTKTAgsxsBqRigMlZhFQiELGLZghRwhKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSChEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrPhasdEfU' } # rubocop:disable Metrics/LineLength
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Implicit Use of "target" Parameter Through Title' do
-    target = 'c:/temp/implicit_target'
+    let(:target) { 'c:/temp/implicit_target' }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Remove Permissions from a Directory' do
-    target = 'c:/temp/rem_perm_dir'
+    let(:target) { 'c:/temp/rem_perm_dir' }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target, true)
+      include_examples 'execute manifest', agent, true
     end
   end
 
   context 'Remove Permissions from a Directory with a Long Name (247 chars)' do
-    target = 'c:/temp/rem_lVTjWTRAaQPPyeaseAsuUhnclarfedIpqIdqwyimqPphcKpojhTHogTUWiaEkiOqbeEZKvNAqDcEjJarQzeNxihARGLytPNseasKZxhRxeCwZsopSUFTKTAgsxsBqRigMlZhFQiELGLZghRwhKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSChEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrPhasdEfU' # rubocop:disable Metrics/LineLength
+    let(:target) { 'c:/temp/rem_lVTjWTRAaQPPyeaseAsuUhnclarfedIpqIdqwyimqPphcKpojhTHogTUWiaEkiOqbeEZKvNAqDcEjJarQzeNxihARGLytPNseasKZxhRxeCwZsopSUFTKTAgsxsBqRigMlZhFQiELGLZghRwhKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSChEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrPhasdEfU' } # rubocop:disable Metrics/LineLength
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(agent, target, true)
+      include_examples 'execute manifest', agent, true
     end
   end
 
   context 'Add Permissions to a Unicode Directory' do
     prefix = SecureRandom.uuid.to_s
-    raw_dirname = prefix + '_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158'
-    dirname =     "#{prefix}_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158"
-    target = "#{target_parent}/#{dirname}"
-
-    verify_acl_command = "(Get-ACL ('#{target_parent}/' + [regex]::Unescape(\"#{raw_dirname}\")) | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match '\\\\bob' -and $_.FileSystemRights -eq 'FullControl' -and $_.InheritanceFlags -eq 'ContainerInherit, ObjectInherit' } | Measure-Object).Count" # rubocop:disable Metrics/LineLength
+    let(:raw_dirname) { prefix + '_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158' }
+    let(:dirname) { "#{prefix}_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158" }
+    let(:target) { "#{target_parent}/#{dirname}" }
+    let(:verify_acl_command) { "(Get-ACL ('#{target_parent}/' + [regex]::Unescape(\"#{raw_dirname}\")) | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match '\\\\bob' -and $_.FileSystemRights -eq 'FullControl' -and $_.InheritanceFlags -eq 'ContainerInherit, ObjectInherit' } | Measure-Object).Count" } # rubocop:disable Metrics/LineLength
+    let(:acl_regex) { %r{^1$} }
 
     windows_agents.each do |agent|
-      it 'Execute Manifest' do
-        execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
-        end
-      end
-
-      it 'Verify that ACL Rights are Correct' do
-        on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-          expect(result.stdout).to match(%r{^1$})
-        end
-      end
+      include_examples 'execute manifest and verify (with PowerShell)', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup, RSpec/RepeatedDescription

--- a/spec/acceptance/parameter_target/perms_on_file_8dot3_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_file_8dot3_spec.rb
@@ -1,47 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup, RSpec/RepeatedDescription
-def apply_manifest_and_verify(file_name, target8dot3, file_content, agent, remove = nil)
-  acl_regex = %r{.*\\bob:\(F\)}
-  verify_acl_command = "icacls #{target_parent}/#{file_name}"
-  verify_content_command = "cat /cygdrive/c/temp/#{file_name}"
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(file_name, target8dot3, file_content), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    if remove
-      it 'Execute Remove Manifest' do
-        execute_manifest_on(agent, acl_manifest_remove(target8dot3), debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
-        end
-      end
-
-      it 'Verify that ACL Rights are Correct' do
-        on(agent, verify_acl_command) do |result|
-          expect(result.stdout).not_to match(%r{#{acl_regex}})
-        end
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Permissions - File - 8.3' do
-  def acl_manifest(file_name, target8dot3, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -68,7 +28,7 @@ describe 'Permissions - File - 8.3' do
     MANIFEST
   end
 
-  def acl_manifest_remove(target8dot3)
+  let(:acl_manifest_remove) do
     <<-MANIFEST
       acl { '#{target8dot3}':
         purge => 'listed_permissions',
@@ -79,24 +39,27 @@ describe 'Permissions - File - 8.3' do
     MANIFEST
   end
 
+  let(:acl_regex) { %r{.*\\bob:\(F\)} }
+  let(:verify_acl_command) { "icacls #{target_parent}/#{file_name}" }
+  let(:verify_content_path) { "#{target_parent}/#{file_name}" }
+
   context 'Add Permissions to 8.3 File' do
-    file_name = 'file_short_name.txt'
-    target8dot3 = 'c:/temp/FILE_S~2.TXT'
-    file_content = 'short file names are very short'
+    let(:file_name) { 'file_short_name.txt' }
+    let(:target8dot3) { 'c:/temp/FILE_S~2.TXT' }
+    let(:file_content) { 'short file names are very short' }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(file_name, target8dot3, file_content, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Remove Permissions from 8.3 File' do
-    file_name = 'rem_file_short_name.txt'
-    target8dot3 = 'c:/temp/REM_FI~2.TXT'
-    file_content = 'wax candle butler space station zebra glasses'
+    let(:file_name) { 'rem_file_short_name.txt' }
+    let(:target8dot3) { 'c:/temp/REM_FI~2.TXT' }
+    let(:file_content) { 'wax candle butler space station zebra glasses' }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(file_name, target8dot3, file_content, agent, true)
+      include_examples 'execute manifest', agent, true
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup, RSpec/RepeatedDescription

--- a/spec/acceptance/parameter_target/perms_on_file_8dot3_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_file_8dot3_spec.rb
@@ -8,33 +8,33 @@ def apply_manifest_and_verify(file_name, target8dot3, file_content, agent, remov
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(file_name, target8dot3, file_content), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     if remove
       it 'Execute Remove Manifest' do
         execute_manifest_on(agent, acl_manifest_remove(target8dot3), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_no_match(acl_regex, result.stdout, 'Unexpected ACL was present!')
+          expect(result.stdout).not_to match(%r{#{acl_regex}})
         end
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end

--- a/spec/acceptance/parameter_target/perms_on_file_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_file_spec.rb
@@ -8,33 +8,33 @@ def apply_manifest_and_verify(file_name, file_content, agent, remove = nil)
   context "on #{agent}" do
     it 'Execute Manifest' do
       execute_manifest_on(agent, acl_manifest(file_name, file_content), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     if remove
       it 'Execute Remove Manifest' do
         execute_manifest_on(agent, acl_manifest_remove(file_name), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_no_match(acl_regex, result.stdout, 'Unexpected ACL was present!')
+          expect(result.stdout).not_to match(%r{#{acl_regex}})
         end
       end
     end
 
     it 'Verify File Data Integrity' do
       on(agent, verify_content_command) do |result|
-        assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
       end
     end
   end
@@ -131,13 +131,13 @@ describe 'Permissions - File' do
     windows_agents.each do |agent|
       it 'Execute Manifest' do
         execute_manifest_on(agent, acl_manifest(file_name, file_content), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-          assert_match(%r{^1$}, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{^1$})
         end
       end
     end

--- a/spec/acceptance/parameter_target/perms_on_file_spec.rb
+++ b/spec/acceptance/parameter_target/perms_on_file_spec.rb
@@ -1,47 +1,7 @@
 require 'spec_helper_acceptance'
 
-# rubocop:disable RSpec/EmptyExampleGroup, RSpec/RepeatedDescription
-def apply_manifest_and_verify(file_name, file_content, agent, remove = nil)
-  acl_regex = %r{.*\\bob:\(F\)}
-  verify_acl_command = "icacls #{target_parent}/#{file_name}"
-  verify_content_command = "cat /cygdrive/c/temp/#{file_name}"
-  context "on #{agent}" do
-    it 'Execute Manifest' do
-      execute_manifest_on(agent, acl_manifest(file_name, file_content), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    if remove
-      it 'Execute Remove Manifest' do
-        execute_manifest_on(agent, acl_manifest_remove(file_name), debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
-        end
-      end
-
-      it 'Verify that ACL Rights are Correct' do
-        on(agent, verify_acl_command) do |result|
-          expect(result.stdout).not_to match(%r{#{acl_regex}})
-        end
-      end
-    end
-
-    it 'Verify File Data Integrity' do
-      on(agent, verify_content_command) do |result|
-        expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-      end
-    end
-  end
-end
-
 describe 'Permissions - File' do
-  def acl_manifest(file_name, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { '#{target_parent}':
         ensure => directory
@@ -68,7 +28,7 @@ describe 'Permissions - File' do
     MANIFEST
   end
 
-  def acl_manifest_remove(file_name)
+  let(:acl_manifest_remove) do
     <<-MANIFEST
       acl { '#{target_parent}/#{file_name}':
         purge => 'listed_permissions',
@@ -79,68 +39,60 @@ describe 'Permissions - File' do
     MANIFEST
   end
 
+  let(:acl_regex) { %r{.*\\bob:\(F\)} }
+  let(:verify_acl_command) { "icacls #{target_parent}/#{file_name}" }
+  let(:verify_content_path) { "#{target_parent}/#{file_name}" }
+
   context 'Add Permissions to a File' do
-    file_name = 'add_perm_file.txt'
-    file_content = 'meowmeowmeow'
+    let(:file_name) { 'add_perm_file.txt' }
+    let(:file_content) { 'meowmeowmeow' }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(file_name, file_content, agent)
+      include_examples 'execute manifest', agent, false, true
     end
   end
 
   context 'Add Permissions to a File with a Long Name (259 chars)' do
-    it 'This test requires PE-3075 to be resolved' do
-      skip
-      file_name = 'dqcEjJarQzeeNxWihARGLytPggNssxewZsopUFUoncTKAgsxsBqRigMlZEdNTEybqlVTjkDWTRASaQPyeeAsuUohncMlarIRphqIdqwyimqPphRTcKpojhTHoAgTUWiaEkiOqbeeEZKvNAhFQiELGLZghRwhKXVHuUPxWghKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSCAhEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrP' # rubocop:disable Metrics/LineLength
-      file_content = 'Salsa Mama! Caliente!'
+    skip 'This test requires PE-3075 to be resolved' do
+      let(:file_name) { 'dqcEjJarQzeeNxWihARGLytPggNssxewZsopUFUoncTKAgsxsBqRigMlZEdNTEybqlVTjkDWTRASaQPyeeAsuUohncMlarIRphqIdqwyimqPphRTcKpojhTHoAgTUWiaEkiOqbeeEZKvNAhFQiELGLZghRwhKXVHuUPxWghKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSCAhEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrP' } # rubocop:disable Metrics/LineLength }
+      let(:file_content) { 'Salsa Mama! Caliente!' }
 
       windows_agents.each do |agent|
-        apply_manifest_and_verify(file_name, file_content, agent)
+        include_examples 'execute manifest', agent, false, true
       end
     end
   end
 
   context 'Remove Permissions from a File' do
-    file_name = 'rem_perm_file.txt'
-    file_content = 'I love puppet, puppet love puppet, puppet love!'
+    let(:file_name) { 'rem_perm_file.txt' }
+    let(:file_content) { 'I love puppet, puppet love puppet, puppet love!' }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(file_name, file_content, agent, true)
+      include_examples 'execute manifest', agent, true, true
     end
   end
 
   context 'Remove Permissions from a File with a Long Name (259 chars)' do
-    it 'This test requires PE-3075 to be resolved' do
-      skip
-      file_name = 'rem_file_zeeNxWihARGLytPggNssxewZsopUFUoncTKAgsxsBqRigMlZEdNTEybqlVTjkDWTRASaQPyeeAsuUohncMlarIRphqIdqwyimqPphRTcKpojhTHoAgTUWiaEkiOqbeeEZKvNAhFQiELGLZghRwhKXVHuUPxWghKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSCAhEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrP' # rubocop:disable Metrics/LineLength
-      file_content = 'Happy Happy Happy Happy Happy!'
+    skip 'This test requires PE-3075 to be resolved' do
+      let(:file_name) { 'rem_file_zeeNxWihARGLytPggNssxewZsopUFUoncTKAgsxsBqRigMlZEdNTEybqlVTjkDWTRASaQPyeeAsuUohncMlarIRphqIdqwyimqPphRTcKpojhTHoAgTUWiaEkiOqbeeEZKvNAhFQiELGLZghRwhKXVHuUPxWghKXVHuUPxWqmeYCHejdQOoGRYqaxwdIqiYyhhSCAhEWlggsGToSLmrgPmotSACKrREyohRBPaKRUmlgCGVtrP' } # rubocop:disable Metrics/LineLength
+      let(:file_content) { 'Happy Happy Happy Happy Happy!' }
 
       windows_agents.each do |agent|
-        apply_manifest_and_verify(file_name, file_content, agent, true)
+        include_examples 'execute manifest', agent, true, true
       end
     end
   end
 
   context 'Add Permissions to a Unicode File' do
     prefix = SecureRandom.uuid.to_s
-    raw_filename = prefix + '_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt'
-    file_name = "#{prefix}_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt"
-    file_content = 'Puppets and Muppets! Cats on the Interwebs!'
-    verify_acl_command = "(Get-Acl ('#{target_parent}/' + [regex]::Unescape(\"#{raw_filename}\")) | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match '\\\\#{user_id}' -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count" # rubocop:disable Metrics/LineLength
+    let(:raw_filename) { prefix + '_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt' }
+    let(:file_name) { "#{prefix}_\u3140\u3145\u3176\u3145\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158.txt" }
+    let(:file_content) { 'Puppets and Muppets! Cats on the Interwebs!' }
+    let(:verify_acl_command) { "(Get-Acl ('#{target_parent}/' + [regex]::Unescape(\"#{raw_filename}\")) | ForEach-Object { $_.Access } | Where-Object { $_.IdentityReference -match '\\\\#{user_id}' -and $_.FileSystemRights -eq 'FullControl' } | Measure-Object).Count" } # rubocop:disable Metrics/LineLength
+    let(:acl_regex) { %r{^1$} }
 
     windows_agents.each do |agent|
-      it 'Execute Manifest' do
-        execute_manifest_on(agent, acl_manifest(file_name, file_content), debug: true) do |result|
-          expect(result.stderr).not_to match(%r{Error:})
-        end
-      end
-
-      it 'Verify that ACL Rights are Correct' do
-        on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
-          expect(result.stdout).to match(%r{^1$})
-        end
-      end
+      include_examples 'execute manifest and verify (with PowerShell)', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup, RSpec/RepeatedDescription

--- a/spec/acceptance/propagation/prop_file_spec.rb
+++ b/spec/acceptance/propagation/prop_file_spec.rb
@@ -64,19 +64,19 @@ describe 'Propagate - Negative' do
           execute_manifest_on(agent, acl_manifest(target_name, file_content, rights, prop_type, affects_child_type), debug: true) do |result|
             verify_manifest = (agent_version >= Gem::Version.new('5.0.0')) ? verify_manifest_pup5 : verify_manifest_pup4
 
-            assert_match(verify_manifest, result.stdout, 'Expected ACL change event not detected!')
+            expect(result.stdout).to match(%r{#{verify_manifest}})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/propagation/prop_file_spec.rb
+++ b/spec/acceptance/propagation/prop_file_spec.rb
@@ -1,5 +1,7 @@
+require 'spec_helper_acceptance'
+
 describe 'Propagate - Negative' do
-  def acl_manifest(target_name, file_content, rights, prop_type, affects_child_type)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -38,47 +40,31 @@ describe 'Propagate - Negative' do
   end
 
   context 'Set Propagation on a File' do
-    rights = 'full'
-    prop_type = 'all'
-    affects_child_type = 'all'
-    file_content = 'Flying beavers attack Lake Oswego!'
-    target_name = 'prop_file'
+    let(:rights) { 'full' }
+    let(:prop_type) { 'all' }
+    let(:affects_child_type) { 'all' }
+    let(:file_content) { 'Flying beavers attack Lake Oswego!' }
+    let(:target_name) { 'prop_file' }
 
-    verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
+    let(:verify_content_path) { "#{target_parent}/#{target_name}" }
 
     # 4c734680aca3b3781ae9fb211759a5610c6679a8 changed how permissions are emitted
     # during a `puppet agent` / `puppet apply` (but not `puppet resource`), so that
     # instead of emitting a [Puppet::Type::Acl::Ace] for rendering to the console
     # a [Hash] is emitted in the permissions_to_s method
     # Puppet 4 and 5 have different behavior for rendering this data structure
-    verify_manifest_pup4 = %r{\{ affects => 'self_only', identity => '.*\\bob', rights => \['full'\s+\] \}}
-    verify_manifest_pup5 = %r{\{"identity"=>".*\\bob", "rights"=>\["full"\], "affects"=>:self_only\}}
+    let(:verify_manifest_pup4) { %r{\{ affects => 'self_only', identity => '.*\\bob', rights => \['full'\s+\] \}} }
+    let(:verify_manifest_pup5) { %r{\{"identity"=>".*\\bob", "rights"=>\["full"\], "affects"=>:self_only\}} }
 
-    verify_acl_command = "icacls #{target_parent}/#{target_name}"
-    acl_regex = %r{.*\\bob:\(F\)}
+    let(:verify_acl_command) { "icacls #{target_parent}/#{target_name}" }
+    let(:acl_regex) { %r{.*\\bob:\(F\)} }
+
     windows_agents.each do |agent|
       context "on #{agent}" do
-        agent_version_response = on(agent, puppet('--version')).stdout.chomp
-        agent_version = Gem::Version.new(agent_version_response)
-        it 'Execute Apply Manifest' do
-          execute_manifest_on(agent, acl_manifest(target_name, file_content, rights, prop_type, affects_child_type), debug: true) do |result|
-            verify_manifest = (agent_version >= Gem::Version.new('5.0.0')) ? verify_manifest_pup5 : verify_manifest_pup4
+        let(:agent_version_response) { on(agent, puppet('--version')).stdout.chomp }
+        let(:agent_version) { Gem::Version.new(agent_version_response) }
 
-            expect(result.stdout).to match(%r{#{verify_manifest}})
-          end
-        end
-
-        it 'Verify that ACL Rights are Correct' do
-          on(agent, verify_acl_command) do |result|
-            expect(result.stdout).to match(%r{#{acl_regex}})
-          end
-        end
-
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-          end
-        end
+        include_examples 'execute manifest and verify file', agent
       end
     end
   end

--- a/spec/acceptance/propagation/prop_self_all_child_spec.rb
+++ b/spec/acceptance/propagation/prop_self_all_child_spec.rb
@@ -1,38 +1,7 @@
 require 'spec_helper_acceptance'
 
-def apply_manifest_and_verify(acl_regex, agent, prop_type, affects_child_type)
-  context "on #{agent}" do
-    rights = 'full'
-    target_name = "prop_#{prop_type}_to_#{affects_child_type}"
-    target_child_name = "prop_#{prop_type}_child"
-    target_child = "#{target_parent}/#{target_name}/#{target_child_name}"
-
-    verify_acl_command = "icacls #{target_parent}/#{target_name}"
-    verify_child_acl_command = "icacls #{target_child}"
-
-    it 'Execute Apply Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, target_child, affects_child_type), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct on Child' do
-      on(agent, verify_child_acl_command) do |result|
-        assert_no_match(acl_regex, result.stdout, 'Unexpected ACL was present!')
-      end
-    end
-  end
-end
-
-# rubocop:disable RSpec/EmptyExampleGroup
 describe 'Propagate' do
-  def acl_manifest(target_name, rights, prop_type, target_child, affects_child_type)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -73,13 +42,21 @@ describe 'Propagate' do
     MANIFEST
   end
 
+  let(:rights) { 'full' }
+  let(:target_name) { "prop_#{prop_type}_to_#{affects_child_type}" }
+  let(:target_child_name) { "prop_#{prop_type}_child" }
+  let(:target_child) { "#{target_parent}/#{target_name}/#{target_child_name}" }
+
+  let(:verify_acl_command) { "icacls #{target_parent}/#{target_name}" }
+  let(:verify_child_acl_command) { "icacls #{target_child}" }
+
   context 'Negative - Propagate "self_only" to "all" Child Types' do
-    prop_type = 'self_only'
-    affects_child_type = 'all'
-    acl_regex = %r{.*\\bob:\(F\)}
+    let(:prop_type) { 'self_only' }
+    let(:affects_child_type) { 'all' }
+    let(:acl_regex) { %r{.*\\bob:\(F\)} }
+
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, prop_type, affects_child_type)
+      include_examples 'execute manifest and verify child', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/propagation/prop_self_all_child_spec.rb
+++ b/spec/acceptance/propagation/prop_self_all_child_spec.rb
@@ -12,13 +12,13 @@ def apply_manifest_and_verify(acl_regex, agent, prop_type, affects_child_type)
 
     it 'Execute Apply Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, target_child, affects_child_type), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 

--- a/spec/acceptance/propagation/prop_self_no_child_spec.rb
+++ b/spec/acceptance/propagation/prop_self_no_child_spec.rb
@@ -1,38 +1,7 @@
 require 'spec_helper_acceptance'
 
-def apply_manifest_and_verify(acl_regex, agent, prop_type)
-  context "on #{agent}" do
-    rights = 'full'
-    target_name = "prop_#{prop_type}"
-    target_child_name = "prop_#{prop_type}_child"
-    target_child = "#{target_parent}/#{target_name}/#{target_child_name}"
-
-    verify_acl_command = "icacls #{target_parent}/#{target_name}"
-    verify_child_acl_command = "icacls #{target_child}"
-
-    it 'Execute Apply Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, target_child), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct on Child' do
-      on(agent, verify_child_acl_command) do |result|
-        expect(result.stdout).not_to match(%r{#{acl_regex}})
-      end
-    end
-  end
-end
-
-# rubocop:disable RSpec/EmptyExampleGroup
 describe 'Propagate' do
-  def acl_manifest(target_name, rights, prop_type, target_child)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -72,12 +41,20 @@ describe 'Propagate' do
     MANIFEST
   end
 
+  let(:rights) { 'full' }
+  let(:target_name) { "prop_#{prop_type}" }
+  let(:target_child_name) { "prop_#{prop_type}_child" }
+  let(:target_child) { "#{target_parent}/#{target_name}/#{target_child_name}" }
+
+  let(:verify_acl_command) { "icacls #{target_parent}/#{target_name}" }
+  let(:verify_child_acl_command) { "icacls #{target_child}" }
+
   context 'Propagate "self_only" to No Child Types' do
-    prop_type = 'self_only'
-    acl_regex = %r{.*\\bob:\(F\)}
+    let(:prop_type) { 'self_only' }
+    let(:acl_regex) { %r{.*\\bob:\(F\)} }
+
     windows_agents.each do |agent|
-      apply_manifest_and_verify(acl_regex, agent, prop_type)
+      include_examples 'execute manifest and verify child', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/propagation/prop_self_no_child_spec.rb
+++ b/spec/acceptance/propagation/prop_self_no_child_spec.rb
@@ -12,19 +12,19 @@ def apply_manifest_and_verify(acl_regex, agent, prop_type)
 
     it 'Execute Apply Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, target_child), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
 
     it 'Verify that ACL Rights are Correct on Child' do
       on(agent, verify_child_acl_command) do |result|
-        assert_no_match(acl_regex, result.stdout, 'Unexpected ACL was present!')
+        expect(result.stdout).not_to match(%r{#{acl_regex}})
       end
     end
   end

--- a/spec/acceptance/propagation/prop_spec.rb
+++ b/spec/acceptance/propagation/prop_spec.rb
@@ -7,13 +7,13 @@ def apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
     verify_acl_command = "icacls #{target_parent}/#{target_name}"
     it 'Execute Apply Manifest' do
       execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, affects_child_type), debug: true) do |result|
-        assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+        expect(result.stderr).not_to match(%r{Error:})
       end
     end
 
     it 'Verify that ACL Rights are Correct' do
       on(agent, verify_acl_command) do |result|
-        assert_match(acl_regex, result.stdout, 'Expected ACL was not present!')
+        expect(result.stdout).to match(%r{#{acl_regex}})
       end
     end
   end

--- a/spec/acceptance/propagation/prop_spec.rb
+++ b/spec/acceptance/propagation/prop_spec.rb
@@ -1,27 +1,7 @@
 require 'spec_helper_acceptance'
 
-def apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
-  context "on #{agent}" do
-    rights = 'full'
-    target_name = "prop_#{prop_type}_to_#{affects_child_type}"
-    verify_acl_command = "icacls #{target_parent}/#{target_name}"
-    it 'Execute Apply Manifest' do
-      execute_manifest_on(agent, acl_manifest(target_name, rights, prop_type, affects_child_type), debug: true) do |result|
-        expect(result.stderr).not_to match(%r{Error:})
-      end
-    end
-
-    it 'Verify that ACL Rights are Correct' do
-      on(agent, verify_acl_command) do |result|
-        expect(result.stdout).to match(%r{#{acl_regex}})
-      end
-    end
-  end
-end
-
-# rubocop:disable RSpec/EmptyExampleGroup
 describe 'Propagation' do
-  def acl_manifest(target_name, rights, prop_type, affects_child_type)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -58,134 +38,137 @@ describe 'Propagation' do
     MANIFEST
   end
 
+  let(:rights) { 'full' }
+  let(:target_name) { "prop_#{prop_type}_to_#{affects_child_type}" }
+  let(:verify_acl_command) { "icacls #{target_parent}/#{target_name}" }
+
   context 'Propagate "all" to "all" Child Types' do
-    prop_type = 'all'
-    affects_child_type = 'all'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
+    let(:prop_type) { 'all' }
+    let(:affects_child_type) { 'all' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "all" to "containers" Child Types' do
-    prop_type = 'all'
-    affects_child_type = 'containers'
-    acl_regex = %r{.*\\bob:\(CI\)\(F\)}
+    let(:prop_type) { 'all' }
+    let(:affects_child_type) { 'containers' }
+    let(:acl_regex) { %r{.*\\bob:\(CI\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "all" to "none" Child Types' do
-    prop_type = 'all'
-    affects_child_type = 'none'
-    acl_regex = %r{.*\\bob:\(F\)}
+    let(:prop_type) { 'all' }
+    let(:affects_child_type) { 'none' }
+    let(:acl_regex) { %r{.*\\bob:\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "all" to "objects" Child Types' do
-    prop_type = 'all'
-    affects_child_type = 'objects'
-    acl_regex = %r{.*\\bob:\(OI\)\(F\)}
+    let(:prop_type) { 'all' }
+    let(:affects_child_type) { 'objects' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "children_only" to "all" Child Types' do
-    prop_type = 'children_only'
-    affects_child_type = 'all'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(IO\)\(F\)}
+    let(:prop_type) { 'children_only' }
+    let(:affects_child_type) { 'all' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(IO\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "children_only" to "containers" Child Types' do
-    prop_type = 'children_only'
-    affects_child_type = 'containers'
-    acl_regex = %r{.*\\bob:\(CI\)\(IO\)\(F\)}
+    let(:prop_type) { 'children_only' }
+    let(:affects_child_type) { 'containers' }
+    let(:acl_regex) { %r{.*\\bob:\(CI\)\(IO\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "children_only" to "objects" Child Types' do
-    prop_type = 'children_only'
-    affects_child_type = 'objects'
-    acl_regex = %r{.*\\bob:\(OI\)\(IO\)\(F\)}
+    let(:prop_type) { 'children_only' }
+    let(:affects_child_type) { 'objects' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(IO\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "direct_children_only" to "all" Child Types' do
-    prop_type = 'direct_children_only'
-    affects_child_type = 'all'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(NP\)\(IO\)\(F\)}
+    let(:prop_type) { 'direct_children_only' }
+    let(:affects_child_type) { 'all' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(NP\)\(IO\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "direct_children_only" to "containers" Child Types' do
-    prop_type = 'direct_children_only'
-    affects_child_type = 'containers'
-    acl_regex = %r{.*\\bob:\(CI\)\(NP\)\(IO\)\(F\)}
+    let(:prop_type) { 'direct_children_only' }
+    let(:affects_child_type) { 'containers' }
+    let(:acl_regex) { %r{.*\\bob:\(CI\)\(NP\)\(IO\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "direct_children_only" to "objects" Child Types' do
-    prop_type = 'direct_children_only'
-    affects_child_type = 'objects'
-    acl_regex = %r{.*\\bob:\(OI\)\(NP\)\(IO\)\(F\)}
+    let(:prop_type) { 'direct_children_only' }
+    let(:affects_child_type) { 'objects' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(NP\)\(IO\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "self_and_direct_children_only" to "all" Child Types' do
-    prop_type = 'self_and_direct_children_only'
-    affects_child_type = 'all'
-    acl_regex = %r{.*\\bob:\(OI\)\(CI\)\(NP\)\(F\)}
+    let(:prop_type) { 'self_and_direct_children_only' }
+    let(:affects_child_type) { 'all' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(CI\)\(NP\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "self_and_direct_children_only" to "containers" Child Types' do
-    prop_type = 'self_and_direct_children_only'
-    affects_child_type = 'containers'
-    acl_regex = %r{.*\\bob:\(CI\)\(NP\)\(F\)}
+    let(:prop_type) { 'self_and_direct_children_only' }
+    let(:affects_child_type) { 'containers' }
+    let(:acl_regex) { %r{.*\\bob:\(CI\)\(NP\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 
   context 'Propagate "self_and_direct_children_only" to "objects" Child Types' do
-    prop_type = 'self_and_direct_children_only'
-    affects_child_type = 'objects'
-    acl_regex = %r{.*\\bob:\(OI\)\(NP\)\(F\)}
+    let(:prop_type) { 'self_and_direct_children_only' }
+    let(:affects_child_type) { 'objects' }
+    let(:acl_regex) { %r{.*\\bob:\(OI\)\(NP\)\(F\)} }
 
     windows_agents.each do |agent|
-      apply_manifest_and_verify(prop_type, affects_child_type, acl_regex, agent)
+      include_examples 'execute manifest', agent
     end
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/acceptance/purge/negative/purge_all_perms_dir_spec.rb
+++ b/spec/acceptance/purge/negative/purge_all_perms_dir_spec.rb
@@ -49,19 +49,19 @@ describe 'Purge' do
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
           execute_manifest_on(agent, acl_manifest(target), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex_user_id, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex_user_id}})
           end
         end
 
         it 'Attempt to Execute Purge Manifest' do
           execute_manifest_on(agent, purge_acl_manifest(target), debug: true, exepect_failures: true) do |result|
-            assert_match(verify_purge_error, result.stderr, 'Expected error was not detected!')
+            expect(result.stderr).to match(%r{#{verify_purge_error}})
           end
         end
       end

--- a/spec/acceptance/purge/negative/purge_all_perms_file_spec.rb
+++ b/spec/acceptance/purge/negative/purge_all_perms_file_spec.rb
@@ -1,25 +1,22 @@
 require 'spec_helper_acceptance'
 
 describe 'Purge' do
-  def acl_manifest(target, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
       }
-
       file { "#{target}":
         ensure  => file,
         content => '#{file_content}',
         require => File['#{target_parent}']
       }
-
       user { "#{user_id}":
         ensure     => present,
         groups     => 'Users',
         managehome => true,
         password   => "L0v3Pupp3t!"
       }
-
       acl { "#{target}":
         permissions  => [
           { identity => '#{user_id}', rights => ['full'] },
@@ -28,7 +25,7 @@ describe 'Purge' do
     MANIFEST
   end
 
-  def purge_acl_manifest(target)
+  let(:acl_manifest_purge) do
     <<-MANIFEST
       acl { "#{target}":
         purge        => 'true',
@@ -39,38 +36,37 @@ describe 'Purge' do
   end
 
   context 'Negative - Purge Absolutely All Permissions from File without Inheritance' do
-    target = "#{target_parent}/purge_all_no_inherit.txt"
-    file_content = 'Breakfast is the most important meal of the day.'
-    verify_content_command = 'cat /cygdrive/c/temp/purge_all_no_inherit.txt'
-    verify_acl_command = "icacls #{target}"
-    acl_regex_user_id = %r{.*\\bob:\(F\)}
+    let(:target) { "#{target_parent}/purge_all_no_inherit.txt" }
+    let(:file_content) { 'Breakfast is the most important meal of the day.' }
+    let(:verify_content_path) { target }
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:acl_regex_user_id) { %r{.*\\bob:\(F\)} }
 
-    verify_purge_error = %r{Error:.*Value for permissions should be an array with at least one element specified}
+    let(:verify_purge_error) { %r{Error:.*Value for permissions should be an array with at least one element specified} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute Apply Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).to match(%r{#{acl_regex_user_id}})
           end
         end
 
-        it 'Attempt to Execute Purge Manifest' do
-          execute_manifest_on(agent, purge_acl_manifest(target), debug: true, exepect_failures: true) do |result|
+        it 'attempts to execute purge, raises error' do
+          execute_manifest_on(agent, acl_manifest_purge, debug: true, exepect_failures: true) do |result|
             expect(result.stderr).to match(%r{#{verify_purge_error}})
           end
         end
 
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-          end
+        it 'verifies file data integrity' do
+          expect(file(verify_content_path)).to be_file
+          expect(file(verify_content_path).content).to match(%r{#{file_content}})
         end
       end
     end

--- a/spec/acceptance/purge/negative/purge_all_perms_file_spec.rb
+++ b/spec/acceptance/purge/negative/purge_all_perms_file_spec.rb
@@ -51,25 +51,25 @@ describe 'Purge' do
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
           execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex_user_id, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex_user_id}})
           end
         end
 
         it 'Attempt to Execute Purge Manifest' do
           execute_manifest_on(agent, purge_acl_manifest(target), debug: true, exepect_failures: true) do |result|
-            assert_match(verify_purge_error, result.stderr, 'Expected error was not detected!')
+            expect(result.stderr).to match(%r{#{verify_purge_error}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/purge/purge_all_other_perms_dir_spec.rb
+++ b/spec/acceptance/purge/purge_all_other_perms_dir_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Purge' do
-  def acl_manifest(target, user_id1, user_id2)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -34,7 +34,7 @@ describe 'Purge' do
     MANIFEST
   end
 
-  def purge_acl_manifest(target, user_id2)
+  let(:acl_manifest_purge) do
     <<-MANIFEST
       acl { "#{target}":
         purge        => 'true',
@@ -47,38 +47,39 @@ describe 'Purge' do
   end
 
   context 'Purge All Other Permissions from Directory without Inheritance' do
-    target = "#{target_parent}/purge_all_other_no_inherit"
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
+    random_username = generate_random_username
+    let(:target) { "#{target_parent}/purge_all_other_no_inherit" }
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { random_username }
 
-    verify_acl_command = "icacls #{target}"
-    acl_regex_user_id1 = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
-    acl_regex_user_id2 = %r{\Ac:\/temp\/purge_all_other_no_inherit.*\\#{user_id2}:\(OI\)\(CI\)\(F\)\n\nSuccessfully}
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:acl_regex_user_id1) { %r{.*\\bob:\(OI\)\(CI\)\(F\)} }
+    let(:acl_regex_user_id2) { %r{\Ac:\/temp\/purge_all_other_no_inherit.*\\#{user_id2}:\(OI\)\(CI\)\(F\)\n\nSuccessfully} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute Apply Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, user_id1, user_id2), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
             assert_match(acl_regex_user_id1, result.stdout, 'Expected ACL was not present!')
-            expect(result.stdout).to match(%r{#{acl_regex}})
+            expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
-        it 'Execute Purge Manifest' do
-          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
+        it 'executes purge' do
+          execute_manifest_on(agent, acl_manifest_purge, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct (Post-Purge)' do
+        it 'verifies ACL rights (post-purge)' do
           on(agent, verify_acl_command, acceptable_exit_codes: [0, 5]) do |result|
-            expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
+            expect(result.stdout).not_to match(%r{#{acl_regex_user_id1}})
             expect(result.stdout).to match(%r{#{acl_regex_user_id2}})
           end
         end

--- a/spec/acceptance/purge/purge_all_other_perms_dir_spec.rb
+++ b/spec/acceptance/purge/purge_all_other_perms_dir_spec.rb
@@ -47,10 +47,6 @@ describe 'Purge' do
   end
 
   context 'Purge All Other Permissions from Directory without Inheritance' do
-    os_check_command = 'cmd /c ver'
-    os_check_regex = %r{Version 5}
-    os_version_win2003 = false
-
     target = "#{target_parent}/purge_all_other_no_inherit"
     user_id1 = 'bob'
     user_id2 = generate_random_username
@@ -58,42 +54,32 @@ describe 'Purge' do
     verify_acl_command = "icacls #{target}"
     acl_regex_user_id1 = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
     acl_regex_user_id2 = %r{\Ac:\/temp\/purge_all_other_no_inherit.*\\#{user_id2}:\(OI\)\(CI\)\(F\)\n\nSuccessfully}
-    acl_regex_win2003 = %r{c:\/temp\/purge_all_other_no_inherit: Access is denied\.}
 
     windows_agents.each do |agent|
-      context "Determine OS Type on #{agent}" do
-        on(agent, os_check_command) do |result|
-          if os_check_regex =~ result.stdout
-            os_version_win2003 = true
-          end
-        end
-
+      context "on #{agent}" do
         it 'Execute Apply Manifest' do
           execute_manifest_on(agent, acl_manifest(target, user_id1, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
             assert_match(acl_regex_user_id1, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex}})
           end
         end
 
         it 'Execute Purge Manifest' do
           execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct (Post-Purge)' do
           on(agent, verify_acl_command, acceptable_exit_codes: [0, 5]) do |result|
-            if os_version_win2003
-              assert_match(acl_regex_win2003, result.stderr, 'Expected failure was not present!')
-            else
-              assert_no_match(acl_regex_user_id1, result.stdout, 'Unexpected ACL was present!')
-              assert_match(acl_regex_user_id2, result.stdout, 'Expected ACL was not present!')
-            end
+            expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
+            expect(result.stdout).to match(%r{#{acl_regex_user_id2}})
           end
         end
       end

--- a/spec/acceptance/purge/purge_all_other_perms_file_spec.rb
+++ b/spec/acceptance/purge/purge_all_other_perms_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Purge' do
-  def acl_manifest(target, file_content, user_id1, user_id2)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -35,7 +35,7 @@ describe 'Purge' do
     MANIFEST
   end
 
-  def purge_acl_manifest(target, user_id2)
+  let(:acl_manifest_purge) do
     <<-MANIFEST
       acl { "#{target}":
         purge        => 'true',
@@ -48,31 +48,31 @@ describe 'Purge' do
   end
 
   context 'Purge All Other Permissions from File without Inheritance' do
-    target = "#{target_parent}/purge_all_other_no_inherit.txt"
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
+    let(:target) { "#{target_parent}/purge_all_other_no_inherit.txt" }
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { generate_random_username }
 
-    file_content = 'All your base are belong to us.'
+    let(:file_content) { 'All your base are belong to us.' }
 
-    verify_acl_command = "icacls #{target}"
-    acl_regex_user_id1 = %r{.*\\bob:\(F\)}
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:acl_regex_user_id1) { %r{.*\\bob:\(F\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute Apply Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
-        it 'Execute Purge Manifest' do
-          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
+        it 'executes purge' do
+          execute_manifest_on(agent, acl_manifest_purge, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end

--- a/spec/acceptance/purge/purge_all_other_perms_file_spec.rb
+++ b/spec/acceptance/purge/purge_all_other_perms_file_spec.rb
@@ -61,19 +61,19 @@ describe 'Purge' do
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
           execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex_user_id1, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
         it 'Execute Purge Manifest' do
           execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
       end

--- a/spec/acceptance/purge/purge_explicit_perms_dir_spec.rb
+++ b/spec/acceptance/purge/purge_explicit_perms_dir_spec.rb
@@ -58,26 +58,26 @@ describe 'Purge' do
       context "on #{agent}" do
         it 'Execute Apply Manifest' do
           execute_manifest_on(agent, acl_manifest(target, user_id1, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex_user_id1, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
         it 'Execute Purge Manifest' do
           execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct (Post-Purge)' do
           on(agent, verify_acl_command) do |result|
-            assert_no_match(acl_regex_user_id1, result.stdout, 'Unexpected ACL was present!')
-            assert_match(acl_regex_user_id2, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).not_to match(%r{#{acl_regex_user_id1}})
+            expect(result.stdout).to match(%r{#{acl_regex_user_id2}})
           end
         end
       end

--- a/spec/acceptance/purge/purge_explicit_perms_dir_spec.rb
+++ b/spec/acceptance/purge/purge_explicit_perms_dir_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Purge' do
-  def acl_manifest(target, user_id1, user_id2)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -34,7 +34,7 @@ describe 'Purge' do
     MANIFEST
   end
 
-  def purge_acl_manifest(target, user_id2)
+  let(:purge_acl_manifest) do
     <<-MANIFEST
       acl { "#{target}":
         purge        => 'true',
@@ -46,35 +46,36 @@ describe 'Purge' do
   end
 
   context 'Only Purge Explicit Permissions from Directory with Inheritance' do
-    target = 'c:/temp/purge_exp_inherit'
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
+    random_username = generate_random_username
+    let(:target) { 'c:/temp/purge_exp_inherit' }
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { random_username }
 
-    verify_acl_command = "icacls #{target}"
-    acl_regex_user_id1 = %r{.*\\bob:\(OI\)\(CI\)\(F\)}
-    acl_regex_user_id2 = %r{.*\\#{user_id2}:\(OI\)\(CI\)\(F\)}
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:acl_regex_user_id1) { %r{.*\\bob:\(OI\)\(CI\)\(F\)} }
+    let(:acl_regex_user_id2) { %r{.*\\#{user_id2}:\(OI\)\(CI\)\(F\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute Apply Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, user_id1, user_id2), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
-        it 'Execute Purge Manifest' do
-          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
+        it 'executes purge' do
+          execute_manifest_on(agent, purge_acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct (Post-Purge)' do
+        it 'verifies ACL rights (post-purge)' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).not_to match(%r{#{acl_regex_user_id1}})
             expect(result.stdout).to match(%r{#{acl_regex_user_id2}})

--- a/spec/acceptance/purge/purge_explicit_perms_file_spec.rb
+++ b/spec/acceptance/purge/purge_explicit_perms_file_spec.rb
@@ -68,26 +68,26 @@ describe 'Purge' do
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(acl_regex_user_id1, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
         it 'Execute Purge Manifest' do
           execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct (Post-Purge)' do
           on(agent, verify_acl_command) do |result|
-            assert_no_match(acl_regex_user_id1, result.stdout, 'Unexpected ACL was present!')
-            assert_match(acl_regex_user_id2, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).not_to match(%r{#{acl_regex_user_id1}})
+            expect(result.stdout).to match(%r{#{acl_regex_user_id2}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'Expected file content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/purge/purge_explicit_perms_file_spec.rb
+++ b/spec/acceptance/purge/purge_explicit_perms_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Purge' do
-  def acl_manifest(target, file_content, user_id1, user_id2)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -35,7 +35,7 @@ describe 'Purge' do
     MANIFEST
   end
 
-  def purge_acl_manifest(target, user_id2)
+  let(:purge_acl_manifest) do
     <<-MANIFEST
       acl { "#{target}":
         purge        => 'true',
@@ -47,48 +47,49 @@ describe 'Purge' do
   end
 
   context 'Negative- Only Purge Explicit Permissions from File with Inheritance' do
-    target = "#{target_parent}/purge_exp_inherit.txt"
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
+    random_username = generate_random_username
 
-    file_content = 'Surge Purge Merge'
-    verify_content_command = 'cat /cygdrive/c/temp/purge_exp_inherit.txt'
+    let(:target) { "#{target_parent}/purge_exp_inherit.txt" }
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { random_username }
 
-    verify_acl_command = "icacls #{target}"
-    acl_regex_user_id1 = %r{.*\\bob:\(F\)}
-    acl_regex_user_id2 = %r{.*\\#{user_id2}:\(F\)}
+    let(:file_content) { 'Surge Purge Merge' }
+    let(:verify_content_path) { target }
+
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:acl_regex_user_id1) { %r{.*\\bob:\(F\)} }
+    let(:acl_regex_user_id2) { %r{.*\\#{user_id2}:\(F\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute Apply Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).to match(%r{#{acl_regex_user_id1}})
           end
         end
 
-        it 'Execute Purge Manifest' do
-          execute_manifest_on(agent, purge_acl_manifest(target, user_id2), debug: true) do |result|
+        it 'executes purge' do
+          execute_manifest_on(agent, purge_acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct (Post-Purge)' do
+        it 'verifies ACL rights (post-purge)' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).not_to match(%r{#{acl_regex_user_id1}})
             expect(result.stdout).to match(%r{#{acl_regex_user_id2}})
           end
         end
 
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-          end
+        it 'verifies file data integrity' do
+          expect(file(verify_content_path)).to be_file
+          expect(file(verify_content_path).content).to match(%r{#{file_content}})
         end
       end
     end

--- a/spec/acceptance/use_cases/complex_prop_inherit_spec.rb
+++ b/spec/acceptance/use_cases/complex_prop_inherit_spec.rb
@@ -152,18 +152,18 @@ describe 'Use Cases' do
           on(agent, verify_acl_grand_child_command) do |result|
             # We only need to check the grand child because we are only concerned with rights
             # propagating and inheriting.
-            assert_match(target_grand_child_first_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_grand_child_second_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_grand_child_third_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_grand_child_fourth_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_grand_child_fifth_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_grand_child_sixth_ace_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{target_grand_child_first_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_grand_child_second_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_grand_child_third_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_grand_child_fourth_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_grand_child_fifth_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_grand_child_sixth_ace_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/use_cases/grant_full_deny_full_spec.rb
+++ b/spec/acceptance/use_cases/grant_full_deny_full_spec.rb
@@ -59,26 +59,26 @@ describe 'Use Cases' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target, target_child, file_content, group, user_id), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct for Child' do
           on(agent, verify_acl_child_command) do |result|
-            assert_match(target_child_first_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_child_second_ace_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{target_child_first_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_child_second_ace_regex}})
           end
         end
 
         it 'Attempt to Update File' do
           execute_manifest_on(agent, update_manifest(target_child), debug: true) do |result|
-            assert_match(%r{Error:}, result.stderr, 'Expected error was not detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/use_cases/multiple_aces_spec.rb
+++ b/spec/acceptance/use_cases/multiple_aces_spec.rb
@@ -95,24 +95,24 @@ describe 'Use Cases' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id3_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id4_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id5_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id6_ace_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{user_id1_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id2_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id3_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id4_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id5_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id6_ace_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/use_cases/multiple_aces_spec.rb
+++ b/spec/acceptance/use_cases/multiple_aces_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Use Cases' do
-  def acl_manifest(target, file_content, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -69,37 +69,39 @@ describe 'Use Cases' do
   end
 
   context 'Multiple ACEs for Target Path' do
-    test_short_name = 'multi_aces'
-    file_content = 'Ninjas all up in my face!'
-    target_name = "use_case_#{test_short_name}.txt"
-    target = "#{target_parent}/#{target_name}"
+    random_username = generate_random_username
 
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
-    user_id3 = 'billy'
-    user_id4 = 'sarah'
-    user_id5 = 'sally'
-    user_id6 = 'betty'
+    let(:test_short_name) { 'multi_aces' }
+    let(:file_content) { 'Ninjas all up in my face!' }
+    let(:target_name) { "use_case_#{test_short_name}.txt" }
+    let(:target) { "#{target_parent}/#{target_name}" }
 
-    verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { random_username }
+    let(:user_id3) { 'billy' }
+    let(:user_id4) { 'sarah' }
+    let(:user_id5) { 'sally' }
+    let(:user_id6) { 'betty' }
 
-    verify_acl_command = "icacls #{target}"
-    user_id1_ace_regex = %r{.*\\bob:\(F\)}
-    user_id2_ace_regex = %r{.*\\#{user_id2}:\(DENY\)\(M\)}
-    user_id3_ace_regex = %r{.*\\billy:\(R\)}
-    user_id4_ace_regex = %r{.*\\sarah:\(DENY\)\(RX\)}
-    user_id5_ace_regex = %r{.*\\sally:\(W,Rc,X,RA\)}
-    user_id6_ace_regex = %r{.*\\betty:\(DENY\)\(R,W\)}
+    let(:verify_content_path) { "#{target_parent}/#{target_name}" }
+
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:user_id1_ace_regex) { %r{.*\\bob:\(F\)} }
+    let(:user_id2_ace_regex) { %r{.*\\#{user_id2}:\(DENY\)\(M\)} }
+    let(:user_id3_ace_regex) { %r{.*\\billy:\(R\)} }
+    let(:user_id4_ace_regex) { %r{.*\\sarah:\(DENY\)\(RX\)} }
+    let(:user_id5_ace_regex) { %r{.*\\sally:\(W,Rc,X,RA\)} }
+    let(:user_id6_ace_regex) { %r{.*\\betty:\(DENY\)\(R,W\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, file_content, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights ' do
           on(agent, verify_acl_command) do |result|
             expect(result.stdout).to match(%r{#{user_id1_ace_regex}})
             expect(result.stdout).to match(%r{#{user_id2_ace_regex}})
@@ -110,10 +112,9 @@ describe 'Use Cases' do
           end
         end
 
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-          end
+        it 'verifies file data integrity' do
+          expect(file(verify_content_path)).to be_file
+          expect(file(verify_content_path).content).to match(%r{#{file_content}})
         end
       end
     end

--- a/spec/acceptance/use_cases/multiple_acls_shared_ident_spec.rb
+++ b/spec/acceptance/use_cases/multiple_acls_shared_ident_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Use Cases' do
-  def acl_manifest(target, target_child, target_grand_child, group1, group2, user_id1, user_id2)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
@@ -76,47 +76,48 @@ describe 'Use Cases' do
   end
 
   context 'Multiple ACL for Nested Paths with Varying Rights for Same Identity' do
-    test_short_name = 'multi_acl_shared_ident'
-    target_name = "use_case_#{test_short_name}"
-    target_child_name = "use_case_child_#{test_short_name}"
-    target_grand_child_name = "use_case_grand_child_#{test_short_name}"
-    target = "#{target_parent}/#{target_name}"
-    target_child = "#{target}/#{target_child_name}"
-    target_grand_child = "#{target_child}/#{target_grand_child_name}"
+    random_username = generate_random_username
+    let(:test_short_name) { 'multi_acl_shared_ident' }
+    let(:target_name) { "use_case_#{test_short_name}" }
+    let(:target_child_name) { "use_case_child_#{test_short_name}" }
+    let(:target_grand_child_name) { "use_case_grand_child_#{test_short_name}" }
+    let(:target) { "#{target_parent}/#{target_name}" }
+    let(:target_child) { "#{target}/#{target_child_name}" }
+    let(:target_grand_child) { "#{target_child}/#{target_grand_child_name}" }
 
-    group1 = 'jerks'
-    group2 = 'cool_peeps'
+    let(:group1) { 'jerks' }
+    let(:group2) { 'cool_peeps' }
 
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { random_username }
 
-    verify_acl_command = "icacls #{target}"
-    verify_acl_child_command = "icacls #{target_child}"
-    verify_acl_grand_child_command = "icacls #{target_grand_child}"
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:verify_acl_child_command) { "icacls #{target_child}" }
+    let(:verify_acl_grand_child_command) { "icacls #{target_grand_child}" }
 
-    target_group1_ace_regex = %r{.*\\jerks:(\(I\))?\(OI\)\(CI\)\(R\)}
-    target_group2_ace_regex = %r{.*\\cool_peeps:(\(I\))?\(OI\)\(CI\)\(R\)}
-    target_user_id1_ace_regex = %r{.*\\bob:(\(I\))?\(OI\)\(CI\)\(R\)}
-    target_user_id2_ace_regex = %r{.*\\#{user_id2}:(\(I\))?\(OI\)\(CI\)\(DENY\)\(RX\)}
+    let(:target_group1_ace_regex) { %r{.*\\jerks:(\(I\))?\(OI\)\(CI\)\(R\)} }
+    let(:target_group2_ace_regex) { %r{.*\\cool_peeps:(\(I\))?\(OI\)\(CI\)\(R\)} }
+    let(:target_user_id1_ace_regex) { %r{.*\\bob:(\(I\))?\(OI\)\(CI\)\(R\)} }
+    let(:target_user_id2_ace_regex) { %r{.*\\#{user_id2}:(\(I\))?\(OI\)\(CI\)\(DENY\)\(RX\)} }
 
-    target_child_group1_ace_regex = %r{.*\\jerks:(\(I\))?\(OI\)\(CI\)\(Rc,S,X,RA\)}
-    target_child_group2_ace_regex = %r{.*\\cool_peeps:(\(I\))?\(OI\)\(CI\)\(Rc,S,X,RA\)}
-    target_child_user_id1_ace_regex = %r{.*\\bob:(\(I\))?\(OI\)\(CI\)\(W,Rc\)}
-    target_child_user_id2_ace_regex = %r{.*\\#{user_id2}:(\(I\))?\(OI\)\(CI\)\(DENY\)\(W,Rc\)}
+    let(:target_child_group1_ace_regex) { %r{.*\\jerks:(\(I\))?\(OI\)\(CI\)\(Rc,S,X,RA\)} }
+    let(:target_child_group2_ace_regex) { %r{.*\\cool_peeps:(\(I\))?\(OI\)\(CI\)\(Rc,S,X,RA\)} }
+    let(:target_child_user_id1_ace_regex) { %r{.*\\bob:(\(I\))?\(OI\)\(CI\)\(W,Rc\)} }
+    let(:target_child_user_id2_ace_regex) { %r{.*\\#{user_id2}:(\(I\))?\(OI\)\(CI\)\(DENY\)\(W,Rc\)} }
 
-    target_grand_child_group1_ace_regex = %r{.*\\jerks:\(OI\)\(CI\)\(F\)}
-    target_grand_child_group2_ace_regex = %r{.*\\cool_peeps:\(OI\)\(CI\)\(F\)}
-    target_grand_child_user_id1_ace_regex = %r{.*\\bob:\(OI\)\(CI\)\(N\)}
-    target_grand_child_user_id2_ace_regex = %r{.*\\#{user_id2}:\(OI\)\(CI\)\(N\)}
+    let(:target_grand_child_group1_ace_regex) { %r{.*\\jerks:\(OI\)\(CI\)\(F\)} }
+    let(:target_grand_child_group2_ace_regex) { %r{.*\\cool_peeps:\(OI\)\(CI\)\(F\)} }
+    let(:target_grand_child_user_id1_ace_regex) { %r{.*\\bob:\(OI\)\(CI\)\(N\)} }
+    let(:target_grand_child_user_id2_ace_regex) { %r{.*\\#{user_id2}:\(OI\)\(CI\)\(N\)} }
 
     windows_agents.each do |agent|
-      it 'Execute ACL Manifest' do
-        execute_manifest_on(agent, acl_manifest(target, target_child, target_grand_child, group1, group2, user_id1, user_id2), debug: true) do |result|
+      it 'applies manifest' do
+        execute_manifest_on(agent, acl_manifest, debug: true) do |result|
           expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
-      it 'Verify that ACL Rights are Correct' do
+      it 'verifies ACL rights' do
         on(agent, verify_acl_command) do |result|
           expect(result.stdout).to match(%r{#{target_group1_ace_regex}})
           expect(result.stdout).to match(%r{#{target_group2_ace_regex}})
@@ -125,7 +126,7 @@ describe 'Use Cases' do
         end
       end
 
-      it 'Verify that ACL Rights are Correct for Child' do
+      it 'verifies child ACL rights' do
         on(agent, verify_acl_child_command) do |result|
           # ACL from parent(s) will still apply.
           expect(result.stdout).to match(%r{#{target_group1_ace_regex}})
@@ -140,7 +141,7 @@ describe 'Use Cases' do
         end
       end
 
-      it 'Verify that ACL Rights are Correct for Grand Child' do
+      it 'verifies grand child ACL rights' do
         on(agent, verify_acl_grand_child_command) do |result|
           # ACL from parent(s) will still apply.
           expect(result.stdout).to match(%r{#{target_group1_ace_regex}})

--- a/spec/acceptance/use_cases/multiple_acls_shared_ident_spec.rb
+++ b/spec/acceptance/use_cases/multiple_acls_shared_ident_spec.rb
@@ -112,52 +112,52 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       it 'Execute ACL Manifest' do
         execute_manifest_on(agent, acl_manifest(target, target_child, target_grand_child, group1, group2, user_id1, user_id2), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_match(target_group1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_group2_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{target_group1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_group2_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_user_id1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_user_id2_ace_regex}})
         end
       end
 
       it 'Verify that ACL Rights are Correct for Child' do
         on(agent, verify_acl_child_command) do |result|
           # ACL from parent(s) will still apply.
-          assert_match(target_group1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_group2_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{target_group1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_group2_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_user_id1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_user_id2_ace_regex}})
 
-          assert_match(target_child_group1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_child_group2_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_child_user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_child_user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{target_child_group1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_child_group2_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_child_user_id1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_child_user_id2_ace_regex}})
         end
       end
 
       it 'Verify that ACL Rights are Correct for Grand Child' do
         on(agent, verify_acl_grand_child_command) do |result|
           # ACL from parent(s) will still apply.
-          assert_match(target_group1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_group2_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{target_group1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_group2_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_user_id1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_user_id2_ace_regex}})
 
           # ACL from parent(s) will still apply.
-          assert_match(target_child_group1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_child_group2_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_child_user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_child_user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{target_child_group1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_child_group2_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_child_user_id1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_child_user_id2_ace_regex}})
 
-          assert_match(target_grand_child_group1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_grand_child_group2_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_grand_child_user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_grand_child_user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).to match(%r{#{target_grand_child_group1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_grand_child_group2_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_grand_child_user_id1_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_grand_child_user_id2_ace_regex}})
         end
       end
     end

--- a/spec/acceptance/use_cases/multiple_acls_spec.rb
+++ b/spec/acceptance/use_cases/multiple_acls_spec.rb
@@ -105,29 +105,29 @@ describe 'Use Cases' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target, target_child, user_id1, user_id2, user_id3, user_id4, user_id5, user_id6), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id3_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_no_match(user_id4_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_no_match(user_id5_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_no_match(user_id6_ace_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{user_id1_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id2_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id3_ace_regex}})
+            expect(result.stdout).not_to match(%r{#{user_id4_ace_regex}})
+            expect(result.stdout).not_to match(%r{#{user_id5_ace_regex}})
+            expect(result.stdout).not_to match(%r{#{user_id6_ace_regex}})
           end
         end
 
         it 'Verify that ACL Rights are Correct for Child' do
           on(agent, verify_acl_child_command) do |result|
-            assert_match(user_id1_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id2_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id3_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id4_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id5_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(user_id6_ace_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{user_id1_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id2_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id3_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id4_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id5_ace_regex}})
+            expect(result.stdout).to match(%r{#{user_id6_ace_regex}})
           end
         end
       end

--- a/spec/acceptance/use_cases/multiple_acls_spec.rb
+++ b/spec/acceptance/use_cases/multiple_acls_spec.rb
@@ -78,28 +78,29 @@ describe 'Use Cases' do
   end
 
   context 'ACL for Parent Path with Separate ACL for Child Path' do
-    test_short_name = 'multi_acl'
-    target_name = "use_case_#{test_short_name}"
-    target_child_name = "use_case_child_#{test_short_name}"
+    random_username = generate_random_username
+    let(:test_short_name) { 'multi_acl' }
+    let(:target_name) { "use_case_#{test_short_name}" }
+    let(:target_child_name) { "use_case_child_#{test_short_name}" }
 
-    target = "#{target_parent}/#{target_name}"
-    target_child = "#{target}/#{target_child_name}"
+    let(:target) { "#{target_parent}/#{target_name}" }
+    let(:target_child) { "#{target}/#{target_child_name}" }
 
-    user_id1 = 'bob'
-    user_id2 = generate_random_username
-    user_id3 = 'billy'
-    user_id4 = 'sarah'
-    user_id5 = 'sally'
-    user_id6 = 'betty'
+    let(:user_id1) { 'bob' }
+    let(:user_id2) { random_username }
+    let(:user_id3) { 'billy' }
+    let(:user_id4) { 'sarah' }
+    let(:user_id5) { 'sally' }
+    let(:user_id6) { 'betty' }
 
-    verify_acl_command = "icacls #{target}"
-    verify_acl_child_command = "icacls #{target_child}"
-    user_id1_ace_regex = %r{.*\\bob:(\(I\))?\(OI\)\(CI\)\(M\)}
-    user_id2_ace_regex = %r{.*\\#{user_id2}:(\(I\))?\(OI\)\(CI\)\(N\)}
-    user_id3_ace_regex = %r{.*\\billy:(\(I\))?\(OI\)\(CI\)\(W,Rc\)}
-    user_id4_ace_regex = %r{.*\\sarah:\(OI\)\(CI\)\(N\)}
-    user_id5_ace_regex = %r{.*\\sally:\(OI\)\(CI\)\(M\)}
-    user_id6_ace_regex = %r{.*\\betty:\(OI\)\(CI\)\(DENY\)\(R\)}
+    let(:verify_acl_command) { "icacls #{target}" }
+    let(:verify_acl_child_command) { "icacls #{target_child}" }
+    let(:user_id1_ace_regex) { %r{.*\\bob:(\(I\))?\(OI\)\(CI\)\(M\)} }
+    let(:user_id2_ace_regex) { %r{.*\\#{user_id2}:(\(I\))?\(OI\)\(CI\)\(N\)} }
+    let(:user_id3_ace_regex) { %r{.*\\billy:(\(I\))?\(OI\)\(CI\)\(W,Rc\)} }
+    let(:user_id4_ace_regex) { %r{.*\\sarah:\(OI\)\(CI\)\(N\)} }
+    let(:user_id5_ace_regex) { %r{.*\\sally:\(OI\)\(CI\)\(M\)} }
+    let(:user_id6_ace_regex) { %r{.*\\betty:\(OI\)\(CI\)\(DENY\)\(R\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do

--- a/spec/acceptance/use_cases/negative/allow_deny_ident_spec.rb
+++ b/spec/acceptance/use_cases/negative/allow_deny_ident_spec.rb
@@ -36,20 +36,20 @@ describe 'Use Cases' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Verify that ACL Rights are Correct' do
           on(agent, verify_acl_command) do |result|
-            assert_match(target_first_ace_regex, result.stdout, 'Expected ACL was not present!')
-            assert_match(target_second_ace_regex, result.stdout, 'Expected ACL was not present!')
+            expect(result.stdout).to match(%r{#{target_first_ace_regex}})
+            expect(result.stdout).to match(%r{#{target_second_ace_regex}})
           end
         end
 
         it 'Verify File Data Integrity' do
           on(agent, verify_content_command) do |result|
-            assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
           end
         end
       end

--- a/spec/acceptance/use_cases/negative/allow_deny_ident_spec.rb
+++ b/spec/acceptance/use_cases/negative/allow_deny_ident_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper_acceptance'
 
 describe 'Use Cases' do
-  def acl_manifest(target, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
       }
 
-      file { "#{target}":
+      file { "#{target_parent}/#{target_file}":
         ensure  => file,
         content => '#{file_content}',
         require => File['#{target_parent}']
       }
 
-      acl { "#{target}":
+      acl { "#{target_parent}/#{target_file}":
         permissions  => [
           { identity => '#{user_id}',perm_type => 'allow', rights => ['full'] },
           { identity => '#{user_id}',perm_type => 'deny', rights => ['full'] }
@@ -23,34 +23,32 @@ describe 'Use Cases' do
   end
 
   context 'Negative - Allow and Deny ACE for Single Identity in ACL' do
-    test_short_name = 'allow_deny_ident'
-    file_content = 'Epic fail'
-    target_name = "use_case_#{test_short_name}.txt"
-    target = "#{target_parent}/#{target_name}"
-    verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
-    verify_acl_command = "icacls #{target}"
-    target_first_ace_regex = %r{.*\\bob:\(F\)}
-    target_second_ace_regex = %r{.*\\bob:\(N\)}
+    let(:test_short_name) { 'allow_deny_ident' }
+    let(:file_content) { 'Epic fail' }
+    let(:target_file) { "use_case_#{test_short_name}.txt" }
+    let(:verify_content_path) { "#{target_parent}/#{target_file}" }
+    let(:verify_acl_command) { "icacls #{target_parent}/#{target_file}" }
+    let(:target_first_ace_regex) { %r{.*\\bob:\(F\)} }
+    let(:target_second_ace_regex) { %r{.*\\bob:\(N\)} }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Verify that ACL Rights are Correct' do
+        it 'verifies ACL rights' do
           on(agent, verify_acl_command) do |result|
-            expect(result.stdout).to match(%r{#{target_first_ace_regex}})
-            expect(result.stdout).to match(%r{#{target_second_ace_regex}})
+            expect(result.stdout).to match(target_first_ace_regex)
+            expect(result.stdout).to match(target_second_ace_regex)
           end
         end
 
-        it 'Verify File Data Integrity' do
-          on(agent, verify_content_command) do |result|
-            expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-          end
+        it 'verifies file data integrity' do
+          expect(file(verify_content_path)).to be_file
+          expect(file(verify_content_path).content).to match(%r{#{file_content}})
         end
       end
     end

--- a/spec/acceptance/use_cases/negative/locked_resource_spec.rb
+++ b/spec/acceptance/use_cases/negative/locked_resource_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper_acceptance'
 
 describe 'Use Cases' do
-  def acl_manifest(target, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
       }
 
-      file { "#{target}":
+      file { "#{target_parent}/#{target_file}":
         ensure  => file,
         content => '#{file_content}',
         require => File['#{target_parent}']
       }
 
-      acl { "#{target}":
+      acl { "#{target_parent}/#{target_file}":
         purge        => 'true',
         permissions  => [
           { identity => '#{user_id}', rights => ['full'] }
@@ -23,9 +23,9 @@ describe 'Use Cases' do
     MANIFEST
   end
 
-  def update_manifest(target)
+  let(:update_manifest) do
     <<-MANIFEST
-      file { "#{target}":
+      file { "#{target_parent}/#{target_file}":
         ensure  => file,
         content => 'New Content'
       }
@@ -33,21 +33,20 @@ describe 'Use Cases' do
   end
 
   context 'Negative - Manage Locked Resource with ACL' do
-    test_short_name = 'locked_resource'
-    file_content = 'Why this hurt bad!'
-    target_name = "use_case_#{test_short_name}.txt"
-    target = "#{target_parent}/#{target_name}"
+    let(:test_short_name) { 'locked_resource' }
+    let(:file_content) { 'Why this hurt bad!' }
+    let(:target_file) { "use_case_#{test_short_name}.txt" }
 
     windows_agents.each do |agent|
       context "on #{agent}" do
-        it 'Execute ACL Manifest' do
-          execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
+        it 'applies manifest' do
+          execute_manifest_on(agent, acl_manifest, debug: true) do |result|
             expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
-        it 'Attempt to Update File' do
-          execute_manifest_on(agent, update_manifest(target), debug: true) do |result|
+        it 'attempts to update file, raises error' do
+          execute_manifest_on(agent, update_manifest, debug: true) do |result|
             expect(result.stderr).to match(%r{Error:.*Permission denied})
           end
         end

--- a/spec/acceptance/use_cases/negative/locked_resource_spec.rb
+++ b/spec/acceptance/use_cases/negative/locked_resource_spec.rb
@@ -42,13 +42,13 @@ describe 'Use Cases' do
       context "on #{agent}" do
         it 'Execute ACL Manifest' do
           execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
-            assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+            expect(result.stderr).not_to match(%r{Error:})
           end
         end
 
         it 'Attempt to Update File' do
           execute_manifest_on(agent, update_manifest(target), debug: true) do |result|
-            assert_match(%r{Error:.*Permission denied}, result.stderr, 'Expected error was not detected!')
+            expect(result.stderr).to match(%r{Error:.*Permission denied})
           end
         end
       end

--- a/spec/acceptance/use_cases/negative/multi_acl_single_target_spec.rb
+++ b/spec/acceptance/use_cases/negative/multi_acl_single_target_spec.rb
@@ -1,27 +1,27 @@
 require 'spec_helper_acceptance'
 
 describe 'Use Cases' do
-  def acl_manifest(target, file_content)
+  let(:acl_manifest) do
     <<-MANIFEST
       file { "#{target_parent}":
         ensure => directory
       }
 
-      file { "#{target}":
+      file { "#{target_parent}/#{target_name}":
         ensure  => file,
         content => '#{file_content}',
         require => File['#{target_parent}']
       }
 
       acl { "first_acl":
-        target       => '#{target}',
+        target       => '#{target_parent}/#{target_name}',
         permissions  => [
           { identity => '#{user_id}',perm_type => 'deny', rights => ['full'] }
         ],
       }
 
       acl { "second_acl":
-        target       => '#{target}',
+        target       => '#{target_parent}/#{target_name}',
         permissions  => [
           { identity => '#{user_id}',perm_type => 'deny', rights => ['full'] }
         ],
@@ -30,35 +30,31 @@ describe 'Use Cases' do
   end
 
   context 'Negative - Multiple ACL for Single Path' do
-    test_short_name = 'multi_acl_single_target'
-    file_content = 'MEGA ULTRA FAIL!'
-    target_name = "use_case_#{test_short_name}.txt"
-    target = "#{target_parent}/#{target_name}"
-
-    verify_content_command = "cat /cygdrive/c/temp/#{target_name}"
-
-    verify_acl_command = "icacls #{target}"
-    target_first_ace_regex = %r{.*\\bob:\(F\)}
-    target_second_ace_regex = %r{.*\\bob:\(N\)}
+    let(:test_short_name) { 'multi_acl_single_target' }
+    let(:file_content) { 'MEGA ULTRA FAIL!' }
+    let(:target_name) { "use_case_#{test_short_name}.txt" }
+    let(:verify_content_path) { "#{target_parent}/#{target_name}" }
+    let(:verify_acl_command) { "icacls #{target_parent}/#{target_name}" }
+    let(:target_first_ace_regex) { %r{.*\\bob:\(F\)} }
+    let(:target_second_ace_regex) { %r{.*\\bob:\(N\)} }
 
     windows_agents.each do |agent|
-      it 'Execute ACL Manifest' do
-        execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
+      it 'applies manifest' do
+        execute_manifest_on(agent, acl_manifest, debug: true) do |result|
           expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
-      it 'Verify that ACL Rights are Correct' do
+      it 'verifies ACL rights' do
         on(agent, verify_acl_command) do |result|
-          expect(result.stdout).not_to match(%r{#{target_first_ace_regex}})
-          expect(result.stdout).to match(%r{#{target_second_ace_regex}})
+          expect(result.stdout).not_to match(target_first_ace_regex)
+          expect(result.stdout).to match(target_second_ace_regex)
         end
       end
 
-      it 'Verify File Data Integrity' do
-        on(agent, verify_content_command) do |result|
-          expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
-        end
+      it 'verifies file data integrity' do
+        expect(file(verify_content_path)).to be_file
+        expect(file(verify_content_path).content).to match(%r{#{file_content}})
       end
     end
   end

--- a/spec/acceptance/use_cases/negative/multi_acl_single_target_spec.rb
+++ b/spec/acceptance/use_cases/negative/multi_acl_single_target_spec.rb
@@ -44,20 +44,20 @@ describe 'Use Cases' do
     windows_agents.each do |agent|
       it 'Execute ACL Manifest' do
         execute_manifest_on(agent, acl_manifest(target, file_content), debug: true) do |result|
-          assert_no_match(%r{Error:}, result.stderr, 'Unexpected error was detected!')
+          expect(result.stderr).not_to match(%r{Error:})
         end
       end
 
       it 'Verify that ACL Rights are Correct' do
         on(agent, verify_acl_command) do |result|
-          assert_no_match(target_first_ace_regex, result.stdout, 'Expected ACL was not present!')
-          assert_match(target_second_ace_regex, result.stdout, 'Expected ACL was not present!')
+          expect(result.stdout).not_to match(%r{#{target_first_ace_regex}})
+          expect(result.stdout).to match(%r{#{target_second_ace_regex}})
         end
       end
 
       it 'Verify File Data Integrity' do
         on(agent, verify_content_command) do |result|
-          assert_match(file_content_regex(file_content), result.stdout, 'File content is invalid!')
+          expect(result.stdout).to match(%r{#{file_content_regex(file_content)}})
         end
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,6 +5,7 @@ require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 require 'beaker/testmode_switcher'
 require 'beaker/testmode_switcher/dsl'
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
 run_puppet_install_helper
 configure_type_defaults_on(hosts)
@@ -14,29 +15,4 @@ install_ca_certs
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 hosts.each do |host|
   install_dev_puppet_module_on(host, source: proj_root, module_name: 'acl')
-end
-
-def target_parent
-  'c:/temp'
-end
-
-def user_id
-  'bob'
-end
-
-def generate_random_username
-  charset = Array('A'..'Z') + Array('a'..'z')
-  Array.new(5) { charset.sample }.join
-end
-
-def file_content_regex(file_content)
-  %r{\A#{file_content}\z}
-end
-
-def windows_agents
-  agents.select { |agent| agent['platform'].include?('windows') }
-end
-
-def linux_agents
-  agents.select { |agent| fact_on(agent, 'kernel') == 'Linux' }
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,0 +1,26 @@
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+
+def target_parent
+  'c:/temp'
+end
+
+def user_id
+  'bob'
+end
+
+def generate_random_username
+  charset = Array('A'..'Z') + Array('a'..'z')
+  Array.new(5) { charset.sample }.join
+end
+
+def file_content_regex(file_content)
+  %r{\A#{file_content}\z}
+end
+
+def windows_agents
+  agents.select { |agent| agent['platform'].include?('windows') }
+end
+
+def linux_agents
+  agents.select { |agent| fact_on(agent, 'kernel') == 'Linux' }
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,87 @@
+shared_examples 'execute manifest' do |agent, remove = false, file_verify = false|
+  it 'applies manifest' do
+    execute_manifest_on(agent, acl_manifest, debug: true) do |result|
+      expect(result.stderr).not_to match(%r{Error:})
+    end
+  end
+
+  it 'verifies ACL rights' do
+    on(agent, verify_acl_command) do |result|
+      expect(result.stdout).to match(%r{#{acl_regex}})
+    end
+  end
+
+  if remove
+    it 'applies remove manifest' do
+      execute_manifest_on(agent, acl_manifest_remove, debug: true) do |result|
+        expect(result.stderr).not_to match(%r{Error:})
+      end
+    end
+
+    it 'verifies ACL rights' do
+      on(agent, verify_acl_command) do |result|
+        expect(result.stdout).not_to match(%r{#{acl_regex}})
+      end
+    end
+  end
+
+  if file_verify
+    it 'verifies file data integrity' do
+      expect(file(verify_content_path)).to be_file
+      expect(file(verify_content_path).content).to match(%r{#{file_content}})
+    end
+  end
+end
+
+shared_examples 'execute manifest and verify file' do |agent|
+  it 'applies manifest' do
+    execute_manifest_on(agent, acl_manifest, debug: true) do |result|
+      expect(result.stderr).not_to match(%r{Error:})
+    end
+  end
+
+  it 'verifies ACL rights' do
+    on(agent, verify_acl_command) do |result|
+      expect(result.stdout).to match(%r{#{acl_regex}})
+    end
+  end
+
+  it 'verifies file data integrity' do
+    expect(file(verify_content_path)).to be_file
+    expect(file(verify_content_path).content).to match(%r{#{file_content}})
+  end
+end
+
+shared_examples 'execute manifest and verify (with PowerShell)' do |agent|
+  it 'applies manifest' do
+    execute_manifest_on(agent, acl_manifest, debug: true) do |result|
+      expect(result.stderr).not_to match(%r{Error:})
+    end
+  end
+
+  it 'verifies ACL rights' do
+    on(agent, powershell(verify_acl_command, 'EncodedCommand' => true)) do |result|
+      expect(result.stdout).to match(acl_regex)
+    end
+  end
+end
+
+shared_examples 'execute manifest and verify child' do |agent|
+  it 'applies manifest' do
+    execute_manifest_on(agent, acl_manifest, debug: true) do |result|
+      expect(result.stderr).not_to match(%r{Error:})
+    end
+  end
+
+  it 'verifies ACL rights' do
+    on(agent, verify_acl_command) do |result|
+      expect(result.stdout).to match(%r{#{acl_regex}})
+    end
+  end
+
+  it 'verifies child ACL rights' do
+    on(agent, verify_child_acl_command) do |result|
+      expect(result.stdout).not_to match(%r{#{acl_regex}})
+    end
+  end
+end


### PR DESCRIPTION
This PR includes two commits providing the following for acceptance tests:
- Use of rspec-expectations
- Use of shared_examples to reduce the amount of boilerplate code and simplify tests