### PR TITLE
MODULES-9569 release prep v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2019-07-23 - Supported Release 3.0.0
+  
+### Summary
+
+Major release which removes support for older versions of Puppet-Agent. Also adds support for Windows Server 2019
+
+#### Features
+
+- Add support for Windows Server 2019 ([FM-7693](https://tickets.puppetlabs.com/browse/FM-7693))
+- Add Puppet Strings docs ([MODULES-9304](https://tickets.puppetlabs.com/browse/MODULES-9304))
+
+#### Bug Fixes
+
+-  Update acceptance tests to improve the quality and efficiency ([MODULES-9294](https://tickets.puppetlabs.com/browse/MODULES-9294))
+
+#### Changed
+
+- Raise lower Puppet bound to 5.5.10 ([MODULES-9297](https://tickets.puppetlabs.com/browse/MODULES-9297))
+
 ## 2018-10-10 - Supported Release 2.1.0
 
 ### Summary

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-acl",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "author": "Puppet Inc",
   "summary": "This module provides the ability to manage ACLs on nodes",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 5.5.10 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Please check the full [changelog](https://github.com/puppetlabs/puppetlabs-acl/compare/2.1.0...2e09adbdcb5065925b5111a3db736abbd3322bfe)

By running[ pdk update ](https://github.com/puppetlabs/puppetlabs-acl/pull/151) some updates were added to metadata file and one of them updated puppet dependency to lower limit: 4.7.0

Basically [this PR](https://github.com/puppetlabs/puppetlabs-acl/pull/152) was removed