### PR TITLE
pdksync - Use abs instead of vmpooler to provision test resources

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,10 +1,10 @@
 ---
 default:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['win-2016-x86_64']
 vagrant:
   provisioner: vagrant
   images: ['gusztavvargadr/windows-server']
 release_checks:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['win-2012-x86_64', 'win-2012r2-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64', 'win-81-x86_64', 'win-10-pro-x86_64']

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'serverspec'
 require 'puppet_litmus'
-require 'pry'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
 PuppetLitmus.configure!


### PR DESCRIPTION
Use abs instead of vmpooler to provision test resources
pdk version: `1.17.0` 
