### PR TITLE
(IAC-1089) Remove dependency on 'win32/security' gem for Puppet 7 compatibility

### DIFF
--- a/lib/puppet/provider/acl/windows/base.rb
+++ b/lib/puppet/provider/acl/windows/base.rb
@@ -16,7 +16,6 @@ class Puppet::Provider::Acl
       if Puppet::Util::Platform.windows?
         require Pathname.new(__FILE__).dirname + '../../../../' + 'puppet/type/acl/ace'
         require 'puppet/util/windows/security'
-        require 'win32/security'
       end
 
       # Used to specify to flush out the SD cache.


### PR DESCRIPTION
The `win32` gems were removed from `puppet-runtime` in
https://github.com/puppetlabs/puppet-runtime/pull/364

We have not been using this gem for some time, so it can be safely
removed.