### PR TITLE
(maint) Update limitations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ To ensure that a specific set of permissions are absent from the ACL, set `purge
 
  * When using SIDs for identities, autorequire tries to match to users with fully qualified names (e.g., User[BUILTIN\Administrators]) in addition to SIDs (User[S-1-5-32-544]). However, it can't match against 'User[Administrators]', because that could cause issues if domain accounts and local accounts share the same name e.g., 'Domain\Bob' and 'LOCAL\Bob'.
 
- * When referring to accounts in the `APPLICATION PACKAGE AUTHORITY`, use either their SID values or their unqualified names. The Windows API has well documented bugs preventing the fully qualifed account names from being used.
+ * When referring to accounts in the `APPLICATION PACKAGE AUTHORITY`, with Puppet versions older than **6.22.0** or **7.5.0**, use either their SID values or their unqualified names. The Windows API has well documented bugs preventing the fully qualifed account names from being used.
 
     * `S-1-15-2-1` or `ALL APPLICATION PACKAGES`, but *not* `APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES`. This account may only be referenced on Windows 2012R2 (kernel 6.3) or newer.
     * `S-1-15-2-2` or `ALL RESTRICTED APPLICATION PACKAGES`, but *not* `APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES`. This account may only be referenced on Windows 2016 (kernel 10.0) or newer.


### PR DESCRIPTION
This commit updates the limitations from readme due to changes done in [PUP-10899](https://tickets.puppetlabs.com/browse/PUP-10899). This pull request should be merged after https://github.com/puppetlabs/puppet/pull/8518 gets merged to be 100% sure that those code changes get indeed released in Puppet `6.22.0` and `7.5.0` as described in this pull request.