### PR TITLE
(MODULES-10908) Fixes for noop behaviour

### DIFF
--- a/lib/puppet/provider/acl/windows/base.rb
+++ b/lib/puppet/provider/acl/windows/base.rb
@@ -566,7 +566,7 @@ class Puppet::Provider::Acl
           case @resource[:target_type]
           when :file
             begin
-              sd = Puppet::Util::Windows::Security.get_security_descriptor(@resource[:target]) unless @resource.noop?
+              sd = Puppet::Util::Windows::Security.get_security_descriptor(@resource[:target]) if ::File.exist?(@resource[:target])
             rescue => detail
               raise Puppet::Error, "Failed to get security descriptor for path '#{@resource[:target]}': #{detail}", detail.backtrace
             end


### PR DESCRIPTION
Running with noop no longer incorrectly reports a pending change when there is none. Using purge and running with noop now correctly reports the pending change.
