### PR TITLE
(GH-260) Update mask docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ acl { 'c:/tempperms':
   permissions                => [
    { identity => 'Administrators', rights => ['full'] }, #full is same as - 2032127 aka 0x1f01ff but you should use 'full'
    { identity => 'SYSTEM', rights => ['modify'] }, #modify is same as 1245631 aka 0x1301bf but you should use 'modify'
-   { identity => 'Users', rights => ['mask_specific'], mask => 1180073 }, #RX WA #0x1201a9
-   { identity => 'Administrator', rights => ['mask_specific'], mask => 1180032 }  #RA,S,WA,Rc #1180032  #0x120180
+   { identity => 'Users', rights => ['mask_specific'], mask => '1180073' }, #RX WA #0x1201a9
+   { identity => 'Administrator', rights => ['mask_specific'], mask => '1180032' }  #RA,S,WA,Rc #1180032  #0x120180
   ],
   inherit_parent_permissions => false,
 }
@@ -398,7 +398,7 @@ Valid identity formats:
  * `identity`: *Required.* Determines whose permissions to manage. If the specified identity doesn't exist on a node, Puppet creates it. Valid options: a user (e.g., 'Bob' or 'TheNet\Bob'), group (e.g., 'Administrators' or 'BUILTIN\Administrators'), or security ID (for example, 'S-1-5-18').
 
 
- * `mask`: *Required if `rights => 'mask_specific'` is set.* Indicates rights granted or denied to the trustee. If the `rights` element isn't set to 'mask_specific', the `mask` element has no effect. Valid options: an integer representing a [permissions mask](http://msdn.microsoft.com/en-us/library/aa394063(v=vs.85).aspx).
+ * `mask`: *Required if `rights => 'mask_specific'` is set.* Indicates rights granted or denied to the trustee. If the `rights` element isn't set to 'mask_specific', the `mask` element has no effect. Valid options: an integer (set as a string, for example '511'), representing a [permissions mask](http://msdn.microsoft.com/en-us/library/aa394063(v=vs.85).aspx).
 
   If you want more granular detail about `mask` values, we've provided an [ACL Mask Rights Addition spreadsheet](https://github.com/puppetlabs/puppetlabs-acl/blob/main/tools/ACL_Access_Rights_Mask_Addition.xlsx) in the acl module's `tools` directory.
 


### PR DESCRIPTION
There has been an oversight in the README outlining the format for mask. Currently the reference documentation and tests use integers wrapped as a string. Updating the README to be inline with all other module documentation.

https://github.com/puppetlabs/puppetlabs-acl/blob/1da1d1315b6d114545960fb40a1f725c805a030d/lib/puppet/type/acl.rb#L203

https://github.com/puppetlabs/puppetlabs-acl/blob/1da1d1315b6d114545960fb40a1f725c805a030d/spec/unit/type/acl/ace_spec.rb#L21
