### PR TITLE
Removing unsupported windows versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,7 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "10",
-        "2008",
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported.

This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.



