### PR TITLE
(MAINT) - update pdk release image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"settings": {
 		"terminal.integrated.profiles.linux": {
 			"bash": {
-				"path": "bash",
+				"path": "bash"
 			}
 		}
 	},

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -34,7 +34,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,12 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '~> 2.0',                                require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 3.0',       require: false
+  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                               require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                               require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                               require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                               require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 3.1',       require: false
   gem "facterdb", '~> 1.18',                           require: false
   gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0',     require: false
   gem "puppetlabs_spec_helper", '>= 3.0.0', '< 5.0.0', require: false

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     "file permissions"
   ],
   "description": "This module provides the ability to manage ACLs on nodes. Currently the only operating system supported is Windows",
-  "pdk-version": "2.5.0",
+  "pdk-version": "2.6.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "tags/2.6.0-0-gd0490b9"
+  "template-ref": "heads/main-0-g9375381"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
This PR updates the pdk release image used in auto_release.yaml from puppet/iac_release:ci to puppet/pdk:2.6.1.0.