### PR TITLE
pdksync - (CAT-1366) - fFix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-acl.git",
   "project_page": "https://github.com/puppetlabs/puppetlabs-acl",
-  "issues_url": "https://tickets.puppet.com/browse/MODULES/component/11945",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-acl/issues",
   "dependencies": [
 
   ],


### PR DESCRIPTION
(CAT-1366) - fFix issue url from old jira to github
pdk version: `2.7.0` 
